### PR TITLE
MOVE MyAudioDevice to OTDefaultAudioDevice

### DIFF
--- a/7.External-Audio-Device/External-Audio-Device.xcodeproj/project.pbxproj
+++ b/7.External-Audio-Device/External-Audio-Device.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		0CBBA414196B5192005F55D4 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CBBA3F3196B5192005F55D4 /* UIKit.framework */; };
 		0CBBA41C196B5192005F55D4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0CBBA41A196B5192005F55D4 /* InfoPlist.strings */; };
 		0CBBA41E196B5192005F55D4 /* External_Audio_DeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CBBA41D196B5192005F55D4 /* External_Audio_DeviceTests.m */; };
-		0CBBA42B196B5314005F55D4 /* MyAudioDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CBBA42A196B5314005F55D4 /* MyAudioDevice.m */; };
+		0CBBA42B196B5314005F55D4 /* OTDefaultAudioDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CBBA42A196B5314005F55D4 /* OTDefaultAudioDevice.m */; };
 		0CBBA435196B5482005F55D4 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CBBA42C196B5482005F55D4 /* AudioToolbox.framework */; };
 		0CBBA436196B5482005F55D4 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CBBA42D196B5482005F55D4 /* AVFoundation.framework */; };
 		0CBBA437196B5482005F55D4 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CBBA42E196B5482005F55D4 /* CoreAudio.framework */; };
@@ -69,8 +69,8 @@
 		0CBBA419196B5192005F55D4 /* External-Audio-DeviceTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "External-Audio-DeviceTests-Info.plist"; sourceTree = "<group>"; };
 		0CBBA41B196B5192005F55D4 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0CBBA41D196B5192005F55D4 /* External_Audio_DeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = External_Audio_DeviceTests.m; sourceTree = "<group>"; };
-		0CBBA429196B5314005F55D4 /* MyAudioDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MyAudioDevice.h; sourceTree = "<group>"; };
-		0CBBA42A196B5314005F55D4 /* MyAudioDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MyAudioDevice.m; sourceTree = "<group>"; };
+		0CBBA429196B5314005F55D4 /* OTDefaultAudioDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTDefaultAudioDevice.h; sourceTree = "<group>"; };
+		0CBBA42A196B5314005F55D4 /* OTDefaultAudioDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTDefaultAudioDevice.m; sourceTree = "<group>"; };
 		0CBBA42C196B5482005F55D4 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		0CBBA42D196B5482005F55D4 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		0CBBA42E196B5482005F55D4 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
@@ -172,8 +172,8 @@
 		0CBBA3F5196B5192005F55D4 /* External-Audio-Device */ = {
 			isa = PBXGroup;
 			children = (
-				0CBBA429196B5314005F55D4 /* MyAudioDevice.h */,
-				0CBBA42A196B5314005F55D4 /* MyAudioDevice.m */,
+				0CBBA429196B5314005F55D4 /* OTDefaultAudioDevice.h */,
+				0CBBA42A196B5314005F55D4 /* OTDefaultAudioDevice.m */,
 				0CBBA3FE196B5192005F55D4 /* AppDelegate.h */,
 				0CBBA3FF196B5192005F55D4 /* AppDelegate.m */,
 				0CBBA401196B5192005F55D4 /* Main_iPhone.storyboard */,
@@ -359,7 +359,7 @@
 			files = (
 				0CBBA409196B5192005F55D4 /* ViewController.m in Sources */,
 				0CBBA400196B5192005F55D4 /* AppDelegate.m in Sources */,
-				0CBBA42B196B5314005F55D4 /* MyAudioDevice.m in Sources */,
+				0CBBA42B196B5314005F55D4 /* OTDefaultAudioDevice.m in Sources */,
 				0CBBA3FC196B5192005F55D4 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/7.External-Audio-Device/External-Audio-Device/OTDefaultAudioDevice.h
+++ b/7.External-Audio-Device/External-Audio-Device/OTDefaultAudioDevice.h
@@ -11,7 +11,7 @@
 #define AUDIO_DEVICE_BLUETOOTH   @"AudioSessionManagerDevice_Bluetooth"
 #define AUDIO_DEVICE_SPEAKER     @"AudioSessionManagerDevice_Speaker"
 
-@interface MyAudioDevice : NSObject <OTAudioDevice>
+@interface OTDefaultAudioDevice : NSObject <OTAudioDevice>
 
 /**
  Returns YES if a wired headset is available.

--- a/7.External-Audio-Device/External-Audio-Device/OTDefaultAudioDevice.m
+++ b/7.External-Audio-Device/External-Audio-Device/OTDefaultAudioDevice.m
@@ -1,10 +1,10 @@
 //
-//  MyAudioDevice.m
+//  OTDefaultAudioDevice.m
 //
 //  Copyright (c) 2014 TokBox, Inc. All rights reserved.
 //
 
-#import "MyAudioDevice.h"
+#import "OTDefaultAudioDevice.h"
 #import <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
 #include <mach/mach.h>
@@ -65,12 +65,12 @@ static OSStatus playout_cb(void *ref_con,
 
 static void print_error(const char* error, OSStatus code);
 
-@interface MyAudioDevice ()
+@interface OTDefaultAudioDevice ()
 - (BOOL) setupAudioForGraph:(AUGraph *)au_graph playout:(BOOL)isPlayout;
 - (void) setupListenerBlocks;
 @end
 
-@implementation MyAudioDevice
+@implementation OTDefaultAudioDevice
 {
     OTAudioFormat *_audioFormat;
     
@@ -783,7 +783,7 @@ static void CheckError(OSStatus error, const char *operation) {
     //fprintf(stderr, "Error: %s (%s)\n", operation, errorString);
 }
 
-static void update_recording_delay(MyAudioDevice* device) {
+static void update_recording_delay(OTDefaultAudioDevice* device) {
     device->_recordingDelayMeasurementCounter++;
     
     if (device->_recordingDelayMeasurementCounter >= 100) {
@@ -834,7 +834,7 @@ static OSStatus recording_cb(void *ref_con,
                              AudioBufferList *data)
 {
 
-    MyAudioDevice *dev = (__bridge MyAudioDevice*) ref_con;
+    OTDefaultAudioDevice *dev = (__bridge OTDefaultAudioDevice*) ref_con;
 
     if (!dev->buffer_list || num_frames > dev->buffer_list_size)
     {
@@ -898,7 +898,7 @@ static OSStatus recording_cb(void *ref_con,
     return noErr;
 }
 
-static void update_playout_delay(MyAudioDevice* device) {
+static void update_playout_delay(OTDefaultAudioDevice* device) {
     device->_playoutDelayMeasurementCounter++;
     
     if (device->_playoutDelayMeasurementCounter >= 100) {
@@ -942,7 +942,7 @@ static OSStatus playout_cb(void *ref_con,
                            UInt32 num_frames,
                            AudioBufferList *buffer_list)
 {
-    MyAudioDevice *dev = (__bridge MyAudioDevice*) ref_con;
+    OTDefaultAudioDevice *dev = (__bridge OTDefaultAudioDevice*) ref_con;
     
     if (!dev->playing) { return 0; }
     

--- a/7.External-Audio-Device/External-Audio-Device/ViewController.m
+++ b/7.External-Audio-Device/External-Audio-Device/ViewController.m
@@ -7,7 +7,7 @@
 
 #import "ViewController.h"
 #import <OpenTok/OpenTok.h>
-#import "MyAudioDevice.h"
+#import "OTDefaultAudioDevice.h"
 
 @interface ViewController ()
 <OTSessionDelegate, OTSubscriberKitDelegate, OTPublisherDelegate>
@@ -18,7 +18,7 @@
     OTSession* _session;
     OTPublisher* _publisher;
     OTSubscriber* _subscriber;
-    MyAudioDevice* _myAudioDevice;
+    OTDefaultAudioDevice* _myAudioDevice;
 }
 static double widgetHeight = 240;
 static double widgetWidth = 320;
@@ -41,7 +41,7 @@ static bool subscribeToSelf = NO;
 {
     [super viewDidLoad];
     
-    _myAudioDevice = [[MyAudioDevice alloc] init];
+    _myAudioDevice = [[OTDefaultAudioDevice alloc] init];
     [OTAudioDeviceManager setAudioDevice:_myAudioDevice];
     
     // Step 1: As the view comes into the foreground, initialize a new instance

--- a/7.External-Audio-Device/README.md
+++ b/7.External-Audio-Device/README.md
@@ -7,11 +7,11 @@ callback, where we set up an audio device before initializing our first OpenTok
 object. It is important to note that audio device setup *must* occur before any
 instance of OTSession or OTPublisher is initialized:
 ```
-_myAudioDevice = [[MyAudioDevice alloc] init];
+_myAudioDevice = [[OTDefaultAudioDevice alloc] init];
 [OTAudioDeviceManager setAudioDevice:_myAudioDevice];
 ```
 
-`MyAudioDevice` is an open source version of the default device driver used in 
+`OTDefaultAudioDevice` is a copy of the default device driver used in 
 the OpenTok iOS SDK. If no audio device is set prior to the first instantiation
 of OTSession, the default driver will be used. A common reason for a developer
 to look at this sample is to debug audio issues in their application. This is


### PR DESCRIPTION
This will make it easier to export the current driver implementation from
private (sdk) repo to public (samples) repo. No need to rename things.