### PR TITLE
TBExampleVideoCapture - plane continuity

### DIFF
--- a/2.Lets-Build-OTPublisher/Lets-Build-OTPublisher/TBExampleVideoCapture.m
+++ b/2.Lets-Build-OTPublisher/Lets-Build-OTPublisher/TBExampleVideoCapture.m
@@ -644,7 +644,7 @@
         
         if (hasNextAddress) {
             size_t planeLength =
-            dataWidth * CVPixelBufferGetHeightOfPlane(imageBuffer, i);
+            dataWidth;
             
             uint8_t* baseAddress =
             CVPixelBufferGetBaseAddressOfPlane(imageBuffer, i);


### PR DESCRIPTION
TBExampleVideoCapture seems overly eager to copy frames, even on unpadded 640x480 capture sources. This PR fixes the plane continuity check in the capturer. Note that padded resolutions such as 480x360, and 352x288 will still be "sanitized" / copied, but its a start.

Discussion: This example doesn't fill out the rowBytes in OTVideoFormat. What does rowBytes do if planar inputs must be contiguous anyways?
