### PR TITLE
MODIFY Set EGL context to nil to prevent crash when deallocating.

### DIFF
--- a/2.Lets-Build-OTPublisher/Lets-Build-OTPublisher/TBExampleVideoRender.m
+++ b/2.Lets-Build-OTPublisher/Lets-Build-OTPublisher/TBExampleVideoRender.m
@@ -149,6 +149,7 @@
     if (appState == UIApplicationStateActive) {
         [self teardownGL];
     }
+    [EAGLContext setCurrentContext:nil];
     [_glContext release];
     [_displayLink invalidate];
     [_displayLink release];


### PR DESCRIPTION
Bug introduced in iOS 9?
From @SteveMcFarlin