### PR TITLE
REFACTOR External Audio Device driver

### DIFF
--- a/7.External-Audio-Device/External-Audio-Device/External-Audio-Device-Info.plist
+++ b/7.External-Audio-Device/External-Audio-Device/External-Audio-Device-Info.plist
@@ -38,6 +38,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>voip</string>
+	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/7.External-Audio-Device/External-Audio-Device/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/7.External-Audio-Device/External-Audio-Device/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",
@@ -16,6 +26,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
       "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
@@ -43,6 +58,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/7.External-Audio-Device/External-Audio-Device/ViewController.m
+++ b/7.External-Audio-Device/External-Audio-Device/ViewController.m
@@ -26,11 +26,11 @@ static double widgetWidth = 320;
 // *** Fill the following variables using your own Project info  ***
 // ***          https://dashboard.tokbox.com/projects            ***
 // Replace with your OpenTok API key
-static NSString* const kApiKey = @"";
+static NSString* const kApiKey = @"100";
 // Replace with your generated session ID
-static NSString* const kSessionId = @"";
+static NSString* const kSessionId = @"2_MX4xMDB-fjE0NTI3MjEzOTA5NzN-MzAwNER6WnY3RWhiY1pLbjFtRTRJS2Nafn4";
 // Replace with your generated token
-static NSString* const kToken = @"";
+static NSString* const kToken = @"T1==cGFydG5lcl9pZD0xMDAmc2RrX3ZlcnNpb249dGJwaHAtdjAuOTEuMjAxMS0wNy0wNSZzaWc9OThjMzUyY2ExN2Q1OGUyMDFhMjY5MTVmZDJlNDQ0ZjU4MTZiNjRhYjpzZXNzaW9uX2lkPTJfTVg0eE1EQi1makUwTlRJM01qRXpPVEE1TnpOLU16QXdORVI2V25ZM1JXaGlZMXBMYmpGdFJUUkpTMk5hZm40JmNyZWF0ZV90aW1lPTE0NTI3MTk2MjMmcm9sZT1tb2RlcmF0b3Imbm9uY2U9MTQ1MjcxOTYyMy45MDg2OTM0MzczNzU4JmV4cGlyZV90aW1lPTE0NTUzMTE2MjM=";
 
 // Change to NO to subscribe to streams other than your own.
 static bool subscribeToSelf = NO;
@@ -226,15 +226,6 @@ didFailWithError:(OTError*)error
     [_subscriber.view setFrame:CGRectMake(0, widgetHeight, widgetWidth,
                                           widgetHeight)];
     [self.view addSubview:_subscriber.view];
-
-    //do audio stuff only after the 2-way chat is in place
-    //detecting just for debug purpose
-    [_myAudioDevice detectCurrentRoute];
-    
-    // change audio route to bluetooth,if present, else headset otherwise device
-    // speakers
-    [_myAudioDevice
-     configureAudioSessionWithDesiredAudioRoute:AUDIO_DEVICE_BLUETOOTH];
 }
 
 - (void)subscriber:(OTSubscriberKit*)subscriber

--- a/7.External-Audio-Device/External-Audio-Device/ViewController.m
+++ b/7.External-Audio-Device/External-Audio-Device/ViewController.m
@@ -26,21 +26,22 @@ static double widgetWidth = 320;
 // *** Fill the following variables using your own Project info  ***
 // ***          https://dashboard.tokbox.com/projects            ***
 // Replace with your OpenTok API key
-static NSString* const kApiKey = @"100";
+static NSString* const kApiKey = @"";
 // Replace with your generated session ID
-static NSString* const kSessionId = @"2_MX4xMDB-fjE0NTI3MjEzOTA5NzN-MzAwNER6WnY3RWhiY1pLbjFtRTRJS2Nafn4";
+static NSString* const kSessionId = @"";
 // Replace with your generated token
-static NSString* const kToken = @"T1==cGFydG5lcl9pZD0xMDAmc2RrX3ZlcnNpb249dGJwaHAtdjAuOTEuMjAxMS0wNy0wNSZzaWc9OThjMzUyY2ExN2Q1OGUyMDFhMjY5MTVmZDJlNDQ0ZjU4MTZiNjRhYjpzZXNzaW9uX2lkPTJfTVg0eE1EQi1makUwTlRJM01qRXpPVEE1TnpOLU16QXdORVI2V25ZM1JXaGlZMXBMYmpGdFJUUkpTMk5hZm40JmNyZWF0ZV90aW1lPTE0NTI3MTk2MjMmcm9sZT1tb2RlcmF0b3Imbm9uY2U9MTQ1MjcxOTYyMy45MDg2OTM0MzczNzU4JmV4cGlyZV90aW1lPTE0NTUzMTE2MjM=";
+static NSString* const kToken = @"";
 
 // Change to NO to subscribe to streams other than your own.
 static bool subscribeToSelf = NO;
+
 
 #pragma mark - View lifecycle
 
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
     _myAudioDevice = [[OTDefaultAudioDevice alloc] init];
     [OTAudioDeviceManager setAudioDevice:_myAudioDevice];
     
@@ -236,6 +237,12 @@ didFailWithError:(OTError*)error
           error);
 }
 
+- (void)subscriberDidDisconnectFromStream:(OTSubscriberKit *)subscriber
+{
+    NSLog(@"subscriberDidDisconnectFromStream %@", subscriber);
+    [self cleanupSubscriber];
+}
+
 # pragma mark - OTPublisher delegate callbacks
 
 - (void)publisher:(OTPublisherKit *)publisher
@@ -254,6 +261,8 @@ didFailWithError:(OTError*)error
 - (void)publisher:(OTPublisherKit*)publisher
   streamDestroyed:(OTStream *)stream
 {
+    NSLog(@"publisher %@ streamDestroyed %@", publisher, stream);
+    
     if ([_subscriber.stream.streamId isEqualToString:stream.streamId])
     {
         [self cleanupSubscriber];


### PR DESCRIPTION
* Prevent races in WebRTC & OS signals
* Prevent races in route/interruption handlers
* Add debugging instrumentation. See `OT_ENABLE_AUDIO_DEBUG`
* Add more error checking to Audio Units & AV Foundation calls
* Remove a modest amount of boilerplate