### PR TITLE
Use AVAudioSessionCategoryAmbient instead

### DIFF
--- a/9.Ringtones/Ringtones/OTAudioDeviceRingtone.m
+++ b/9.Ringtones/Ringtones/OTAudioDeviceRingtone.m
@@ -61,7 +61,7 @@
     // cause problems if a publisher is running.
     if (!self.isCapturing && !self.isRendering) {
         AVAudioSession* audioSession = [AVAudioSession sharedInstance];
-        [audioSession setCategory:AVAudioSessionCategoryPlayback
+        [audioSession setCategory:AVAudioSessionCategoryAmbient
                             error:nil];
         [audioSession setActive:YES error:nil];
     }


### PR DESCRIPTION
Recommend we use AVAudioSessionCategoryAmbient here to honor the user silencing their phone.