### PR TITLE
Fix issue with switching on iPhone between phone mode and speaker mode for audio output

### DIFF
--- a/7.External-Audio-Device/External-Audio-Device/OTDefaultAudioDevice.m
+++ b/7.External-Audio-Device/External-Audio-Device/OTDefaultAudioDevice.m
@@ -432,7 +432,6 @@ static bool CheckError(OSStatus error, NSString* function) {
                                       error:nil];
     
     NSUInteger audioOptions = AVAudioSessionCategoryOptionMixWithOthers |
-    AVAudioSessionCategoryOptionDefaultToSpeaker |
     AVAudioSessionCategoryOptionAllowBluetooth;
     [mySession setCategory:AVAudioSessionCategoryPlayAndRecord
                withOptions:audioOptions


### PR DESCRIPTION
In this PR fixed issue in AudioDriver when you can't switch speaker on iPhone from big to small (to make calls in phone mode)

I prepared a small demo to show that with "AVAudioSessionCategoryOptionDefaultToSpeaker" you can't switch audio output to small speaker
https://github.com/sbokatuk/opentok-ios-sdk-samples/tree/test/7.External-Audio-Device
run app with your session values - and on iPhone you can switch to small speaker,

but when you uncomment this row
https://github.com/sbokatuk/opentok-ios-sdk-samples/blob/test/7.External-Audio-Device/External-Audio-Device/OTDefaultAudioDevice.m#L451
you will be not able to switch...

I'm also proposing to make same fix for default opentok driver, because when we make binding library for using in Xamarin .Net projects - it's impossible to wrote good custom audio driver to fix this switching speakers issue