### PR TITLE
Update project configurations: remove libpods references

### DIFF
--- a/1.Hello-World/Hello-World.xcodeproj/project.pbxproj
+++ b/1.Hello-World/Hello-World.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		9D89045C83BA0E4D2E9745EF /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FAF0E6D86210263CECC6A3B9 /* libPods.a */; };
+		03A85A44E030153E1061D31B /* libPods-Hello-WorldTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 07F09A74A40BDB337161758A /* libPods-Hello-WorldTests.a */; };
 		D4426101185F81D800E23699 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D44260FF185F81D800E23699 /* InfoPlist.strings */; };
 		D4426103185F81D800E23699 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D4426102185F81D800E23699 /* main.m */; };
 		D4426107185F81D800E23699 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D4426106185F81D800E23699 /* AppDelegate.m */; };
@@ -20,6 +20,7 @@
 		D4426123185F81D800E23699 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D4426121185F81D800E23699 /* InfoPlist.strings */; };
 		D4426125185F81D800E23699 /* Hello_WorldTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D4426124185F81D800E23699 /* Hello_WorldTests.m */; };
 		D442614C185F92C000E23699 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = D442614B185F92BF00E23699 /* README.md */; };
+		D4D55F6C1D5E160B008DC3AD /* libPods-Hello-World.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D55F6B1D5E160B008DC3AD /* libPods-Hello-World.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,9 +35,14 @@
 
 /* Begin PBXFileReference section */
 		00BACA06E8CDB759A9349E08 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		07F09A74A40BDB337161758A /* libPods-Hello-WorldTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Hello-WorldTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C16853B1A71949A00A507E3 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
+		2B710F9C8F6081B4B94172C5 /* Pods-Hello-WorldTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hello-WorldTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Hello-WorldTests/Pods-Hello-WorldTests.release.xcconfig"; sourceTree = "<group>"; };
+		4C7569C7C0E5AA3DB7CB5998 /* Pods-Hello-World.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hello-World.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Hello-World/Pods-Hello-World.debug.xcconfig"; sourceTree = "<group>"; };
+		58AE6BC6D9E2846DCFF31A82 /* Pods-Hello-WorldTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hello-WorldTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Hello-WorldTests/Pods-Hello-WorldTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A5D01FB21A3A133C005D84F9 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		A9594D9D1BA292CF1D7DFE4F /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		ABCE318488C50D6D9DF10334 /* Pods-Hello-World.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hello-World.release.xcconfig"; path = "Pods/Target Support Files/Pods-Hello-World/Pods-Hello-World.release.xcconfig"; sourceTree = "<group>"; };
 		D44260F3185F81D800E23699 /* Hello-World.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hello-World.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D44260F6185F81D800E23699 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D44260F8185F81D800E23699 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -68,6 +74,8 @@
 		D4426148185F8F5000E23699 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		D442614B185F92BF00E23699 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		D492D19019547E4C00F4F534 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		D4D55F6B1D5E160B008DC3AD /* libPods-Hello-World.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-Hello-World.a"; path = "../../../Library/Developer/Xcode/DerivedData/Hello-World-fvvtmwacfbzjjderquqykxqtaapp/Build/Products/Debug-iphonesimulator/libPods-Hello-World.a"; sourceTree = "<group>"; };
+		EC00452EF808ED505E813D8C /* libPods-Hello-World.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Hello-World.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAF0E6D86210263CECC6A3B9 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -76,7 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9D89045C83BA0E4D2E9745EF /* libPods.a in Frameworks */,
+				D4D55F6C1D5E160B008DC3AD /* libPods-Hello-World.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,6 +94,7 @@
 			files = (
 				D442611B185F81D800E23699 /* UIKit.framework in Frameworks */,
 				D442611A185F81D800E23699 /* Foundation.framework in Frameworks */,
+				03A85A44E030153E1061D31B /* libPods-Hello-WorldTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,6 +106,10 @@
 			children = (
 				A9594D9D1BA292CF1D7DFE4F /* Pods.debug.xcconfig */,
 				00BACA06E8CDB759A9349E08 /* Pods.release.xcconfig */,
+				4C7569C7C0E5AA3DB7CB5998 /* Pods-Hello-World.debug.xcconfig */,
+				ABCE318488C50D6D9DF10334 /* Pods-Hello-World.release.xcconfig */,
+				58AE6BC6D9E2846DCFF31A82 /* Pods-Hello-WorldTests.debug.xcconfig */,
+				2B710F9C8F6081B4B94172C5 /* Pods-Hello-WorldTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -125,6 +138,7 @@
 		D44260F5185F81D800E23699 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D4D55F6B1D5E160B008DC3AD /* libPods-Hello-World.a */,
 				0C16853B1A71949A00A507E3 /* libc++.dylib */,
 				A5D01FB21A3A133C005D84F9 /* VideoToolbox.framework */,
 				D442612E185F82AB00E23699 /* OpenTok.framework */,
@@ -142,6 +156,8 @@
 				D44260F8185F81D800E23699 /* CoreGraphics.framework */,
 				D44260FA185F81D800E23699 /* UIKit.framework */,
 				FAF0E6D86210263CECC6A3B9 /* libPods.a */,
+				EC00452EF808ED505E813D8C /* libPods-Hello-World.a */,
+				07F09A74A40BDB337161758A /* libPods-Hello-WorldTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -197,11 +213,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D4426128185F81D800E23699 /* Build configuration list for PBXNativeTarget "Hello-World" */;
 			buildPhases = (
-				EFC642817FFA643DBA2BE3B9 /* Check Pods Manifest.lock */,
+				EFC642817FFA643DBA2BE3B9 /* 📦 Check Pods Manifest.lock */,
 				D44260EF185F81D800E23699 /* Sources */,
 				D44260F0185F81D800E23699 /* Frameworks */,
 				D44260F1185F81D800E23699 /* Resources */,
-				6BCB70CF839CC031482FB46A /* Copy Pods Resources */,
+				6BCB70CF839CC031482FB46A /* 📦 Copy Pods Resources */,
+				BE14926A190FCEBAD58D9673 /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -216,9 +233,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D442612B185F81D800E23699 /* Build configuration list for PBXNativeTarget "Hello-WorldTests" */;
 			buildPhases = (
+				223814A5EEC1179ACF686636 /* 📦 Check Pods Manifest.lock */,
 				D4426113185F81D800E23699 /* Sources */,
 				D4426114185F81D800E23699 /* Frameworks */,
 				D4426115185F81D800E23699 /* Resources */,
+				3193DF0E13699D11F551F75D /* 📦 Embed Pods Frameworks */,
+				827D0FBD50FFE9C7551726BA /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -287,29 +307,89 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6BCB70CF839CC031482FB46A /* Copy Pods Resources */ = {
+		223814A5EEC1179ACF686636 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		EFC642817FFA643DBA2BE3B9 /* Check Pods Manifest.lock */ = {
+		3193DF0E13699D11F551F75D /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Hello-WorldTests/Pods-Hello-WorldTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6BCB70CF839CC031482FB46A /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Hello-World/Pods-Hello-World-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		827D0FBD50FFE9C7551726BA /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Hello-WorldTests/Pods-Hello-WorldTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BE14926A190FCEBAD58D9673 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Hello-World/Pods-Hello-World-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EFC642817FFA643DBA2BE3B9 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -452,7 +532,7 @@
 		};
 		D4426129185F81D800E23699 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A9594D9D1BA292CF1D7DFE4F /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 4C7569C7C0E5AA3DB7CB5998 /* Pods-Hello-World.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -471,7 +551,7 @@
 		};
 		D442612A185F81D800E23699 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 00BACA06E8CDB759A9349E08 /* Pods.release.xcconfig */;
+			baseConfigurationReference = ABCE318488C50D6D9DF10334 /* Pods-Hello-World.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -490,6 +570,7 @@
 		};
 		D442612C185F81D800E23699 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 58AE6BC6D9E2846DCFF31A82 /* Pods-Hello-WorldTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Hello-World.app/Hello-World";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -512,6 +593,7 @@
 		};
 		D442612D185F81D800E23699 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2B710F9C8F6081B4B94172C5 /* Pods-Hello-WorldTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Hello-World.app/Hello-World";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/2.Lets-Build-OTPublisher/Lets-Build-OTPublisher.xcodeproj/project.pbxproj
+++ b/2.Lets-Build-OTPublisher/Lets-Build-OTPublisher.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0C1685381A71932900A507E3 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C1685371A71932900A507E3 /* libc++.dylib */; };
 		A5D01FA81A3A124C005D84F9 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D01FA71A3A124C005D84F9 /* VideoToolbox.framework */; };
+		CA00CF5B5D480784BE1E593A /* libPods-Lets-Build-OTPublisher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CA931693B8F0523173C32BF /* libPods-Lets-Build-OTPublisher.a */; };
+		D346C658BC90E6754241919F /* libPods-Lets-Build-OTPublisherTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ECAD8ADD724BD49184B76BF3 /* libPods-Lets-Build-OTPublisherTests.a */; };
 		D442615E185FA27400E23699 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D442615D185FA27400E23699 /* Foundation.framework */; };
 		D4426160185FA27400E23699 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D442615F185FA27400E23699 /* CoreGraphics.framework */; };
 		D4426162185FA27400E23699 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4426161185FA27400E23699 /* UIKit.framework */; };
@@ -39,7 +41,6 @@
 		D44261BB185FA64100E23699 /* ShaderUtilities.c in Sources */ = {isa = PBXBuildFile; fileRef = D44261B8185FA64100E23699 /* ShaderUtilities.c */; };
 		D44261D5185FADAB00E23699 /* TBExampleVideoCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = D44261D4185FADAB00E23699 /* TBExampleVideoCapture.m */; };
 		D44261D8185FAED800E23699 /* TBExampleSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = D44261D7185FAED800E23699 /* TBExampleSubscriber.m */; };
-		D4873B2AFBABB0B876A84A96 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DE0B7E4999C8669CFE3DDD4 /* libPods.a */; };
 		D4F8FD9F194125E300364672 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F8FD9E194125E300364672 /* GLKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -56,7 +57,11 @@
 /* Begin PBXFileReference section */
 		0C1685371A71932900A507E3 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		2DE0B7E4999C8669CFE3DDD4 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F2AC6EF28931086EF68449B /* Pods-Lets-Build-OTPublisherTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lets-Build-OTPublisherTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Lets-Build-OTPublisherTests/Pods-Lets-Build-OTPublisherTests.release.xcconfig"; sourceTree = "<group>"; };
+		8E83AA23345F74D6AABB6CFB /* Pods-Lets-Build-OTPublisher.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lets-Build-OTPublisher.release.xcconfig"; path = "Pods/Target Support Files/Pods-Lets-Build-OTPublisher/Pods-Lets-Build-OTPublisher.release.xcconfig"; sourceTree = "<group>"; };
+		9CA931693B8F0523173C32BF /* libPods-Lets-Build-OTPublisher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Lets-Build-OTPublisher.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5D01FA71A3A124C005D84F9 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
+		C876258B5D33B67B130C1E51 /* Pods-Lets-Build-OTPublisherTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lets-Build-OTPublisherTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Lets-Build-OTPublisherTests/Pods-Lets-Build-OTPublisherTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CBCA2C0A5D5DC7D0A4465332 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		D442615A185FA27400E23699 /* Lets-Build-OTPublisher.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Lets-Build-OTPublisher.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D442615D185FA27400E23699 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -99,7 +104,9 @@
 		D44261D6185FAED800E23699 /* TBExampleSubscriber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TBExampleSubscriber.h; sourceTree = "<group>"; };
 		D44261D7185FAED800E23699 /* TBExampleSubscriber.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TBExampleSubscriber.m; sourceTree = "<group>"; };
 		D4F8FD9E194125E300364672 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		ECAD8ADD724BD49184B76BF3 /* libPods-Lets-Build-OTPublisherTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Lets-Build-OTPublisherTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F080383D0BBAC932371EEE9F /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		FDFBDB4E6A52ED55EA777D25 /* Pods-Lets-Build-OTPublisher.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Lets-Build-OTPublisher.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Lets-Build-OTPublisher/Pods-Lets-Build-OTPublisher.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,7 +130,7 @@
 				D4426196185FA35F00E23699 /* OpenTok.framework in Frameworks */,
 				D4426162185FA27400E23699 /* UIKit.framework in Frameworks */,
 				D442615E185FA27400E23699 /* Foundation.framework in Frameworks */,
-				D4873B2AFBABB0B876A84A96 /* libPods.a in Frameworks */,
+				CA00CF5B5D480784BE1E593A /* libPods-Lets-Build-OTPublisher.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,6 +140,7 @@
 			files = (
 				D4426182185FA27400E23699 /* UIKit.framework in Frameworks */,
 				D4426181185FA27400E23699 /* Foundation.framework in Frameworks */,
+				D346C658BC90E6754241919F /* libPods-Lets-Build-OTPublisherTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,6 +152,10 @@
 			children = (
 				CBCA2C0A5D5DC7D0A4465332 /* Pods.debug.xcconfig */,
 				F080383D0BBAC932371EEE9F /* Pods.release.xcconfig */,
+				FDFBDB4E6A52ED55EA777D25 /* Pods-Lets-Build-OTPublisher.debug.xcconfig */,
+				8E83AA23345F74D6AABB6CFB /* Pods-Lets-Build-OTPublisher.release.xcconfig */,
+				C876258B5D33B67B130C1E51 /* Pods-Lets-Build-OTPublisherTests.debug.xcconfig */,
+				3F2AC6EF28931086EF68449B /* Pods-Lets-Build-OTPublisherTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -189,6 +201,8 @@
 				D442615F185FA27400E23699 /* CoreGraphics.framework */,
 				D4426161185FA27400E23699 /* UIKit.framework */,
 				2DE0B7E4999C8669CFE3DDD4 /* libPods.a */,
+				9CA931693B8F0523173C32BF /* libPods-Lets-Build-OTPublisher.a */,
+				ECAD8ADD724BD49184B76BF3 /* libPods-Lets-Build-OTPublisherTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -254,11 +268,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D442618F185FA27400E23699 /* Build configuration list for PBXNativeTarget "Lets-Build-OTPublisher" */;
 			buildPhases = (
-				4470D3C3B09B0E2E9472C83A /* Check Pods Manifest.lock */,
+				4470D3C3B09B0E2E9472C83A /* 📦 Check Pods Manifest.lock */,
 				D4426156185FA27400E23699 /* Sources */,
 				D4426157185FA27400E23699 /* Frameworks */,
 				D4426158185FA27400E23699 /* Resources */,
-				25FAD9C3916448A15EF6C000 /* Copy Pods Resources */,
+				25FAD9C3916448A15EF6C000 /* 📦 Copy Pods Resources */,
+				490FA7E60C78501B9FFD4FC9 /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -273,9 +288,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D4426192185FA27400E23699 /* Build configuration list for PBXNativeTarget "Lets-Build-OTPublisherTests" */;
 			buildPhases = (
+				4A4EBE73FD52AA4A91C49ACF /* 📦 Check Pods Manifest.lock */,
 				D442617A185FA27400E23699 /* Sources */,
 				D442617B185FA27400E23699 /* Frameworks */,
 				D442617C185FA27400E23699 /* Resources */,
+				05F41AA43F2A7D4F1A7AD140 /* 📦 Embed Pods Frameworks */,
+				8B5D41A9D960E243B4C3FD7C /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -344,34 +362,94 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		25FAD9C3916448A15EF6C000 /* Copy Pods Resources */ = {
+		05F41AA43F2A7D4F1A7AD140 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Lets-Build-OTPublisherTests/Pods-Lets-Build-OTPublisherTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4470D3C3B09B0E2E9472C83A /* Check Pods Manifest.lock */ = {
+		25FAD9C3916448A15EF6C000 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Lets-Build-OTPublisher/Pods-Lets-Build-OTPublisher-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4470D3C3B09B0E2E9472C83A /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		490FA7E60C78501B9FFD4FC9 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Lets-Build-OTPublisher/Pods-Lets-Build-OTPublisher-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4A4EBE73FD52AA4A91C49ACF /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		8B5D41A9D960E243B4C3FD7C /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Lets-Build-OTPublisherTests/Pods-Lets-Build-OTPublisherTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -520,7 +598,7 @@
 		};
 		D4426190185FA27400E23699 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBCA2C0A5D5DC7D0A4465332 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = FDFBDB4E6A52ED55EA777D25 /* Pods-Lets-Build-OTPublisher.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -541,7 +619,7 @@
 		};
 		D4426191185FA27400E23699 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F080383D0BBAC932371EEE9F /* Pods.release.xcconfig */;
+			baseConfigurationReference = 8E83AA23345F74D6AABB6CFB /* Pods-Lets-Build-OTPublisher.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -562,6 +640,7 @@
 		};
 		D4426193185FA27400E23699 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C876258B5D33B67B130C1E51 /* Pods-Lets-Build-OTPublisherTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Lets-Build-OTPublisher.app/Lets-Build-OTPublisher";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -584,6 +663,7 @@
 		};
 		D4426194185FA27400E23699 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3F2AC6EF28931086EF68449B /* Pods-Lets-Build-OTPublisherTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Lets-Build-OTPublisher.app/Lets-Build-OTPublisher";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/3.Live-Photo-Capture/Live-Photo-Capture.xcodeproj/project.pbxproj
+++ b/3.Live-Photo-Capture/Live-Photo-Capture.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0C1685341A71930400A507E3 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C1685331A71930400A507E3 /* libc++.dylib */; };
-		4084F0A549E1E765B414BB8F /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 010D3F96249136D12074DC44 /* libPods.a */; };
+		42A4881122554387AA8D3E6B /* libPods-Live-Photo-Capture.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EF6F6ABBDCA57CB4BB169729 /* libPods-Live-Photo-Capture.a */; };
+		9E9E9770EAD7D4A03FBFE71B /* libPods-Live-Photo-CaptureTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CAA93CAF3C1D733118BC00CA /* libPods-Live-Photo-CaptureTests.a */; };
 		A5D01FAA1A3A1270005D84F9 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D01FA91A3A1270005D84F9 /* VideoToolbox.framework */; };
 		D44261E6185FC8D600E23699 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D44261E5185FC8D600E23699 /* Foundation.framework */; };
 		D44261E8185FC8D600E23699 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D44261E7185FC8D600E23699 /* CoreGraphics.framework */; };
@@ -55,10 +56,15 @@
 
 /* Begin PBXFileReference section */
 		010D3F96249136D12074DC44 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		06A34ED525EECEE0323D00B5 /* Pods-Live-Photo-CaptureTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Live-Photo-CaptureTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Live-Photo-CaptureTests/Pods-Live-Photo-CaptureTests.debug.xcconfig"; sourceTree = "<group>"; };
 		0C1685331A71930400A507E3 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
+		35339DD51D5BEAE1338B949A /* Pods-Live-Photo-Capture.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Live-Photo-Capture.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Live-Photo-Capture/Pods-Live-Photo-Capture.debug.xcconfig"; sourceTree = "<group>"; };
+		54D5FF3A0FED5CB24D1C93A5 /* Pods-Live-Photo-Capture.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Live-Photo-Capture.release.xcconfig"; path = "Pods/Target Support Files/Pods-Live-Photo-Capture/Pods-Live-Photo-Capture.release.xcconfig"; sourceTree = "<group>"; };
 		7A1CE4C39F459356ECE734B0 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		84751FC6C5192595645DEB7D /* Pods-Live-Photo-CaptureTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Live-Photo-CaptureTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Live-Photo-CaptureTests/Pods-Live-Photo-CaptureTests.release.xcconfig"; sourceTree = "<group>"; };
 		A5D01FA91A3A1270005D84F9 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		A8EC553B5E91745453413441 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		CAA93CAF3C1D733118BC00CA /* libPods-Live-Photo-CaptureTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Live-Photo-CaptureTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D44261E2185FC8D600E23699 /* Live-Photo-Capture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Live-Photo-Capture.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D44261E5185FC8D600E23699 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D44261E7185FC8D600E23699 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -98,6 +104,7 @@
 		D4426244185FCF2900E23699 /* TBExampleVideoRender.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TBExampleVideoRender.m; path = "../2.Lets-Build-OTPublisher/Lets-Build-OTPublisher/TBExampleVideoRender.m"; sourceTree = "<group>"; };
 		D4426247185FCF6A00E23699 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		D4F8FD9C194125D100364672 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		EF6F6ABBDCA57CB4BB169729 /* libPods-Live-Photo-Capture.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Live-Photo-Capture.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,7 +128,7 @@
 				D442621E185FC9F800E23699 /* OpenTok.framework in Frameworks */,
 				D44261EA185FC8D600E23699 /* UIKit.framework in Frameworks */,
 				D44261E6185FC8D600E23699 /* Foundation.framework in Frameworks */,
-				4084F0A549E1E765B414BB8F /* libPods.a in Frameworks */,
+				42A4881122554387AA8D3E6B /* libPods-Live-Photo-Capture.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,6 +138,7 @@
 			files = (
 				D442620A185FC8D600E23699 /* UIKit.framework in Frameworks */,
 				D4426209185FC8D600E23699 /* Foundation.framework in Frameworks */,
+				9E9E9770EAD7D4A03FBFE71B /* libPods-Live-Photo-CaptureTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -142,6 +150,10 @@
 			children = (
 				7A1CE4C39F459356ECE734B0 /* Pods.debug.xcconfig */,
 				A8EC553B5E91745453413441 /* Pods.release.xcconfig */,
+				35339DD51D5BEAE1338B949A /* Pods-Live-Photo-Capture.debug.xcconfig */,
+				54D5FF3A0FED5CB24D1C93A5 /* Pods-Live-Photo-Capture.release.xcconfig */,
+				06A34ED525EECEE0323D00B5 /* Pods-Live-Photo-CaptureTests.debug.xcconfig */,
+				84751FC6C5192595645DEB7D /* Pods-Live-Photo-CaptureTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -188,6 +200,8 @@
 				D44261E7185FC8D600E23699 /* CoreGraphics.framework */,
 				D44261E9185FC8D600E23699 /* UIKit.framework */,
 				010D3F96249136D12074DC44 /* libPods.a */,
+				EF6F6ABBDCA57CB4BB169729 /* libPods-Live-Photo-Capture.a */,
+				CAA93CAF3C1D733118BC00CA /* libPods-Live-Photo-CaptureTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -258,11 +272,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D4426217185FC8D600E23699 /* Build configuration list for PBXNativeTarget "Live-Photo-Capture" */;
 			buildPhases = (
-				FB54381AFFEF01E66E202600 /* Check Pods Manifest.lock */,
+				FB54381AFFEF01E66E202600 /* 📦 Check Pods Manifest.lock */,
 				D44261DE185FC8D600E23699 /* Sources */,
 				D44261DF185FC8D600E23699 /* Frameworks */,
 				D44261E0185FC8D600E23699 /* Resources */,
-				DA57C878154D9C8A1CB3F51A /* Copy Pods Resources */,
+				DA57C878154D9C8A1CB3F51A /* 📦 Copy Pods Resources */,
+				02DBC0736913E71C5F394FB1 /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -277,9 +292,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D442621A185FC8D600E23699 /* Build configuration list for PBXNativeTarget "Live-Photo-CaptureTests" */;
 			buildPhases = (
+				75A997181C8D372AF0880D96 /* 📦 Check Pods Manifest.lock */,
 				D4426202185FC8D600E23699 /* Sources */,
 				D4426203185FC8D600E23699 /* Frameworks */,
 				D4426204185FC8D600E23699 /* Resources */,
+				30CA5E99F60E414FCE655EE2 /* 📦 Embed Pods Frameworks */,
+				35A1A04790D9CADB4581261E /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -348,29 +366,89 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		DA57C878154D9C8A1CB3F51A /* Copy Pods Resources */ = {
+		02DBC0736913E71C5F394FB1 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Live-Photo-Capture/Pods-Live-Photo-Capture-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FB54381AFFEF01E66E202600 /* Check Pods Manifest.lock */ = {
+		30CA5E99F60E414FCE655EE2 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Live-Photo-CaptureTests/Pods-Live-Photo-CaptureTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		35A1A04790D9CADB4581261E /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Live-Photo-CaptureTests/Pods-Live-Photo-CaptureTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		75A997181C8D372AF0880D96 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		DA57C878154D9C8A1CB3F51A /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Live-Photo-Capture/Pods-Live-Photo-Capture-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FB54381AFFEF01E66E202600 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -524,7 +602,7 @@
 		};
 		D4426218185FC8D600E23699 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7A1CE4C39F459356ECE734B0 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 35339DD51D5BEAE1338B949A /* Pods-Live-Photo-Capture.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -549,7 +627,7 @@
 		};
 		D4426219185FC8D600E23699 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A8EC553B5E91745453413441 /* Pods.release.xcconfig */;
+			baseConfigurationReference = 54D5FF3A0FED5CB24D1C93A5 /* Pods-Live-Photo-Capture.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -574,6 +652,7 @@
 		};
 		D442621B185FC8D600E23699 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 06A34ED525EECEE0323D00B5 /* Pods-Live-Photo-CaptureTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Live-Photo-Capture.app/Live-Photo-Capture";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -596,6 +675,7 @@
 		};
 		D442621C185FC8D600E23699 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 84751FC6C5192595645DEB7D /* Pods-Live-Photo-CaptureTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Live-Photo-Capture.app/Live-Photo-Capture";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/4.Overlay-Graphics/Overlay-Graphics.xcodeproj/project.pbxproj
+++ b/4.Overlay-Graphics/Overlay-Graphics.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0C1685301A71927700A507E3 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C16852F1A71927700A507E3 /* libc++.dylib */; };
+		9EC79D7A4D839EBB4C1272B0 /* libPods-Overlay-GraphicsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A3B375B86A4474C95B0B7ED /* libPods-Overlay-GraphicsTests.a */; };
 		A535047718FD469B00E68BD9 /* archiving_off-Small.png in Resources */ = {isa = PBXBuildFile; fileRef = A535047118FD469B00E68BD9 /* archiving_off-Small.png */; };
 		A535047818FD469B00E68BD9 /* archiving_off-Small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A535047218FD469B00E68BD9 /* archiving_off-Small@2x.png */; };
 		A535047918FD469B00E68BD9 /* archiving_on-10.png in Resources */ = {isa = PBXBuildFile; fileRef = A535047318FD469B00E68BD9 /* archiving_on-10.png */; };
@@ -56,7 +57,7 @@
 		A5FA8EEC1A5DE18A002DC195 /* swapCamera.png in Resources */ = {isa = PBXBuildFile; fileRef = A5FA8EE31A5DE18A002DC195 /* swapCamera.png */; };
 		A5FA8EED1A5DE18A002DC195 /* unmutePublisher.png in Resources */ = {isa = PBXBuildFile; fileRef = A5FA8EE41A5DE18A002DC195 /* unmutePublisher.png */; };
 		A5FA8EEE1A5DE18A002DC195 /* unmuteSubscriber.png in Resources */ = {isa = PBXBuildFile; fileRef = A5FA8EE51A5DE18A002DC195 /* unmuteSubscriber.png */; };
-		BA946EC419EB3A3D73AAA194 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 91DD8E06C3F2152B79C8E169 /* libPods.a */; };
+		BC8CA3BABC31DF1B0A8DF9B1 /* libPods-Overlay-Graphics.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A54187ECDD139BE13A584FE7 /* libPods-Overlay-Graphics.a */; };
 		D4F8FDAA1941277B00364672 /* TBExampleVideoCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = D4F8FDA71941277B00364672 /* TBExampleVideoCapture.m */; };
 		D4F8FDAB1941277B00364672 /* TBExampleVideoRender.m in Sources */ = {isa = PBXBuildFile; fileRef = D4F8FDA91941277B00364672 /* TBExampleVideoRender.m */; };
 		D4F8FDAD194129B900364672 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F8FDAC194129B900364672 /* GLKit.framework */; };
@@ -74,8 +75,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A3B375B86A4474C95B0B7ED /* libPods-Overlay-GraphicsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Overlay-GraphicsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C16852F1A71927700A507E3 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
 		36E39CD914172B59A2E936DB /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		3A8B605D2A23C06A5390F2BC /* Pods-Overlay-Graphics.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Overlay-Graphics.release.xcconfig"; path = "Pods/Target Support Files/Pods-Overlay-Graphics/Pods-Overlay-Graphics.release.xcconfig"; sourceTree = "<group>"; };
+		4C67DB97EA5524020ED8D617 /* Pods-Overlay-GraphicsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Overlay-GraphicsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Overlay-GraphicsTests/Pods-Overlay-GraphicsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8CB048233FBE70F982E65FBA /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		91DD8E06C3F2152B79C8E169 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A535047118FD469B00E68BD9 /* archiving_off-Small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "archiving_off-Small.png"; sourceTree = "<group>"; };
@@ -84,6 +88,7 @@
 		A535047418FD469B00E68BD9 /* archiving_on-10@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "archiving_on-10@2x.png"; sourceTree = "<group>"; };
 		A535047518FD469B00E68BD9 /* archiving_pulse-Small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "archiving_pulse-Small.png"; sourceTree = "<group>"; };
 		A535047618FD469B00E68BD9 /* archiving_pulse-Small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "archiving_pulse-Small@2x.png"; sourceTree = "<group>"; };
+		A54187ECDD139BE13A584FE7 /* libPods-Overlay-Graphics.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Overlay-Graphics.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5595EBC19C9512A0040B99C /* Headset.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Headset.png; sourceTree = "<group>"; };
 		A5595EBD19C9512A0040B99C /* Headset@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Headset@2x.png"; sourceTree = "<group>"; };
 		A5595ED219CAD5810040B99C /* silhouette.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = silhouette.png; sourceTree = "<group>"; };
@@ -145,6 +150,8 @@
 		D4F8FDA91941277B00364672 /* TBExampleVideoRender.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TBExampleVideoRender.m; path = "../2.Lets-Build-OTPublisher/Lets-Build-OTPublisher/TBExampleVideoRender.m"; sourceTree = "<group>"; };
 		D4F8FDAC194129B900364672 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		D4F8FDAE194129C400364672 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
+		E77577DA4E1EC79235664DFF /* Pods-Overlay-GraphicsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Overlay-GraphicsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Overlay-GraphicsTests/Pods-Overlay-GraphicsTests.release.xcconfig"; sourceTree = "<group>"; };
+		FC633EEFF09BA9F8B04B27E4 /* Pods-Overlay-Graphics.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Overlay-Graphics.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Overlay-Graphics/Pods-Overlay-Graphics.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,7 +173,7 @@
 				D4F8FDAD194129B900364672 /* GLKit.framework in Frameworks */,
 				A56B2BAE18C085AD001E082A /* UIKit.framework in Frameworks */,
 				A56B2BAA18C085AD001E082A /* Foundation.framework in Frameworks */,
-				BA946EC419EB3A3D73AAA194 /* libPods.a in Frameworks */,
+				BC8CA3BABC31DF1B0A8DF9B1 /* libPods-Overlay-Graphics.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,6 +183,7 @@
 			files = (
 				A56B2BCE18C085AE001E082A /* UIKit.framework in Frameworks */,
 				A56B2BCD18C085AD001E082A /* Foundation.framework in Frameworks */,
+				9EC79D7A4D839EBB4C1272B0 /* libPods-Overlay-GraphicsTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -221,6 +229,8 @@
 				A56B2BAB18C085AD001E082A /* CoreGraphics.framework */,
 				A56B2BAD18C085AD001E082A /* UIKit.framework */,
 				91DD8E06C3F2152B79C8E169 /* libPods.a */,
+				A54187ECDD139BE13A584FE7 /* libPods-Overlay-Graphics.a */,
+				0A3B375B86A4474C95B0B7ED /* libPods-Overlay-GraphicsTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -327,6 +337,10 @@
 			children = (
 				8CB048233FBE70F982E65FBA /* Pods.debug.xcconfig */,
 				36E39CD914172B59A2E936DB /* Pods.release.xcconfig */,
+				FC633EEFF09BA9F8B04B27E4 /* Pods-Overlay-Graphics.debug.xcconfig */,
+				3A8B605D2A23C06A5390F2BC /* Pods-Overlay-Graphics.release.xcconfig */,
+				4C67DB97EA5524020ED8D617 /* Pods-Overlay-GraphicsTests.debug.xcconfig */,
+				E77577DA4E1EC79235664DFF /* Pods-Overlay-GraphicsTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -338,11 +352,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A56B2BDB18C085AE001E082A /* Build configuration list for PBXNativeTarget "Overlay-Graphics" */;
 			buildPhases = (
-				2807BCDE3AA8E4BAE7145FDC /* Check Pods Manifest.lock */,
+				2807BCDE3AA8E4BAE7145FDC /* 📦 Check Pods Manifest.lock */,
 				A56B2BA218C085AD001E082A /* Sources */,
 				A56B2BA318C085AD001E082A /* Frameworks */,
 				A56B2BA418C085AD001E082A /* Resources */,
-				AD79C3A75670A80B326013F1 /* Copy Pods Resources */,
+				AD79C3A75670A80B326013F1 /* 📦 Copy Pods Resources */,
+				FAB49610D559625AE23193E0 /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -357,9 +372,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A56B2BDE18C085AE001E082A /* Build configuration list for PBXNativeTarget "Overlay-GraphicsTests" */;
 			buildPhases = (
+				89DE07C7EDD792E9FC9FC3E6 /* 📦 Check Pods Manifest.lock */,
 				A56B2BC618C085AD001E082A /* Sources */,
 				A56B2BC718C085AD001E082A /* Frameworks */,
 				A56B2BC818C085AD001E082A /* Resources */,
+				205A907839143B5757FA89B1 /* 📦 Embed Pods Frameworks */,
+				C9231FB3080536CA45048E0D /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -445,14 +463,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2807BCDE3AA8E4BAE7145FDC /* Check Pods Manifest.lock */ = {
+		205A907839143B5757FA89B1 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Overlay-GraphicsTests/Pods-Overlay-GraphicsTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2807BCDE3AA8E4BAE7145FDC /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -460,19 +493,64 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		AD79C3A75670A80B326013F1 /* Copy Pods Resources */ = {
+		89DE07C7EDD792E9FC9FC3E6 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		AD79C3A75670A80B326013F1 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Overlay-Graphics/Pods-Overlay-Graphics-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C9231FB3080536CA45048E0D /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Overlay-GraphicsTests/Pods-Overlay-GraphicsTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FAB49610D559625AE23193E0 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Overlay-Graphics/Pods-Overlay-Graphics-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -626,7 +704,7 @@
 		};
 		A56B2BDC18C085AE001E082A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8CB048233FBE70F982E65FBA /* Pods.debug.xcconfig */;
+			baseConfigurationReference = FC633EEFF09BA9F8B04B27E4 /* Pods-Overlay-Graphics.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -653,7 +731,7 @@
 		};
 		A56B2BDD18C085AE001E082A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 36E39CD914172B59A2E936DB /* Pods.release.xcconfig */;
+			baseConfigurationReference = 3A8B605D2A23C06A5390F2BC /* Pods-Overlay-Graphics.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -680,6 +758,7 @@
 		};
 		A56B2BDF18C085AE001E082A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4C67DB97EA5524020ED8D617 /* Pods-Overlay-GraphicsTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Overlay-Graphics.app/Overlay-Graphics";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -702,6 +781,7 @@
 		};
 		A56B2BE018C085AE001E082A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E77577DA4E1EC79235664DFF /* Pods-Overlay-GraphicsTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Overlay-Graphics.app/Overlay-Graphics";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/5.Multi-Party-Call/Multi-Party-Call.xcodeproj/project.pbxproj
+++ b/5.Multi-Party-Call/Multi-Party-Call.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01C9497A05EB942A405F78F3 /* libPods-Multi-Party-CallTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A381A5531DF89E7F66743B69 /* libPods-Multi-Party-CallTests.a */; };
 		0C16852E1A71925600A507E3 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C16852D1A71925600A507E3 /* libc++.dylib */; };
 		A554AFA7190A9B3100A6910E /* archiving_on-5.png in Resources */ = {isa = PBXBuildFile; fileRef = A554AF90190A9B3100A6910E /* archiving_on-5.png */; };
 		A554AFA8190A9B3100A6910E /* archiving_on-5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A554AF91190A9B3100A6910E /* archiving_on-5@2x.png */; };
@@ -62,8 +63,8 @@
 		A5B6113F18F29AA100841E6B /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A5B6113E18F29AA100841E6B /* libsqlite3.dylib */; };
 		A5B6114218F29B7400841E6B /* ShaderUtilities.c in Sources */ = {isa = PBXBuildFile; fileRef = A5B6114018F29B7400841E6B /* ShaderUtilities.c */; };
 		A5D01FB61A3A136E005D84F9 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D01FB51A3A136E005D84F9 /* VideoToolbox.framework */; };
-		ACC065185C660423903CA96C /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 74E2051E9CAEB905DFBB7C96 /* libPods.a */; };
 		D492D19419547ECF00F4F534 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D492D19319547ECF00F4F534 /* GLKit.framework */; };
+		EE536D01CE945FD49ADD88B1 /* libPods-Multi-Party-Call.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 061F8613C72DE7F14A396BD6 /* libPods-Multi-Party-Call.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,9 +78,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		061F8613C72DE7F14A396BD6 /* libPods-Multi-Party-Call.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Multi-Party-Call.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C16852D1A71925600A507E3 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
+		1AFF0C35675122ABDB60918F /* Pods-Multi-Party-Call.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Multi-Party-Call.release.xcconfig"; path = "Pods/Target Support Files/Pods-Multi-Party-Call/Pods-Multi-Party-Call.release.xcconfig"; sourceTree = "<group>"; };
 		32C9E834B2AC4F7798E0C4B0 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		46E5EF39F9308BD8F61C221E /* Pods-Multi-Party-CallTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Multi-Party-CallTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Multi-Party-CallTests/Pods-Multi-Party-CallTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74E2051E9CAEB905DFBB7C96 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		76F642B75E225B22C6B09C28 /* Pods-Multi-Party-Call.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Multi-Party-Call.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Multi-Party-Call/Pods-Multi-Party-Call.debug.xcconfig"; sourceTree = "<group>"; };
+		A381A5531DF89E7F66743B69 /* libPods-Multi-Party-CallTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Multi-Party-CallTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A554AF90190A9B3100A6910E /* archiving_on-5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "archiving_on-5.png"; sourceTree = "<group>"; };
 		A554AF91190A9B3100A6910E /* archiving_on-5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "archiving_on-5@2x.png"; sourceTree = "<group>"; };
 		A554AF92190A9B3100A6910E /* archiving_pulse-15.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "archiving_pulse-15.png"; sourceTree = "<group>"; };
@@ -142,6 +148,7 @@
 		A5D01FB51A3A136E005D84F9 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		B025DECC3717D60FD82CE247 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		D492D19319547ECF00F4F534 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		DB3F032E054DBDBAB2AEA34D /* Pods-Multi-Party-CallTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Multi-Party-CallTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Multi-Party-CallTests/Pods-Multi-Party-CallTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,7 +169,7 @@
 				A5B6113B18F29A9800841E6B /* CoreVideo.framework in Frameworks */,
 				A5B6113D18F29A9A00841E6B /* CoreMedia.framework in Frameworks */,
 				A5B610EE18F2845100841E6B /* Foundation.framework in Frameworks */,
-				ACC065185C660423903CA96C /* libPods.a in Frameworks */,
+				EE536D01CE945FD49ADD88B1 /* libPods-Multi-Party-Call.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,6 +179,7 @@
 			files = (
 				A5B6111218F2845100841E6B /* UIKit.framework in Frameworks */,
 				A5B6111118F2845100841E6B /* Foundation.framework in Frameworks */,
+				01C9497A05EB942A405F78F3 /* libPods-Multi-Party-CallTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -183,6 +191,10 @@
 			children = (
 				B025DECC3717D60FD82CE247 /* Pods.debug.xcconfig */,
 				32C9E834B2AC4F7798E0C4B0 /* Pods.release.xcconfig */,
+				76F642B75E225B22C6B09C28 /* Pods-Multi-Party-Call.debug.xcconfig */,
+				1AFF0C35675122ABDB60918F /* Pods-Multi-Party-Call.release.xcconfig */,
+				46E5EF39F9308BD8F61C221E /* Pods-Multi-Party-CallTests.debug.xcconfig */,
+				DB3F032E054DBDBAB2AEA34D /* Pods-Multi-Party-CallTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -224,6 +236,8 @@
 				A5B610EF18F2845100841E6B /* CoreGraphics.framework */,
 				A5B610F118F2845100841E6B /* UIKit.framework */,
 				74E2051E9CAEB905DFBB7C96 /* libPods.a */,
+				061F8613C72DE7F14A396BD6 /* libPods-Multi-Party-Call.a */,
+				A381A5531DF89E7F66743B69 /* libPods-Multi-Party-CallTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -312,11 +326,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A5B6111F18F2845100841E6B /* Build configuration list for PBXNativeTarget "Multi-Party-Call" */;
 			buildPhases = (
-				17764ADFE73DC38314090330 /* Check Pods Manifest.lock */,
+				17764ADFE73DC38314090330 /* 📦 Check Pods Manifest.lock */,
 				A5B610E618F2845100841E6B /* Sources */,
 				A5B610E718F2845100841E6B /* Frameworks */,
 				A5B610E818F2845100841E6B /* Resources */,
-				681E6C6C5B35313110552B6D /* Copy Pods Resources */,
+				681E6C6C5B35313110552B6D /* 📦 Copy Pods Resources */,
+				5A33A391D0F65CD1F9F64FEE /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -331,9 +346,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A5B6112218F2845100841E6B /* Build configuration list for PBXNativeTarget "Multi-Party-CallTests" */;
 			buildPhases = (
+				25E3685C39C10ECEC12E8024 /* 📦 Check Pods Manifest.lock */,
 				A5B6110A18F2845100841E6B /* Sources */,
 				A5B6110B18F2845100841E6B /* Frameworks */,
 				A5B6110C18F2845100841E6B /* Resources */,
+				2F4951FA8F2B51C588275B55 /* 📦 Embed Pods Frameworks */,
+				4D0BC9E454610B3D09A8B2BC /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -432,14 +450,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		17764ADFE73DC38314090330 /* Check Pods Manifest.lock */ = {
+		17764ADFE73DC38314090330 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -447,19 +465,79 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		681E6C6C5B35313110552B6D /* Copy Pods Resources */ = {
+		25E3685C39C10ECEC12E8024 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		2F4951FA8F2B51C588275B55 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Multi-Party-CallTests/Pods-Multi-Party-CallTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4D0BC9E454610B3D09A8B2BC /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Multi-Party-CallTests/Pods-Multi-Party-CallTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5A33A391D0F65CD1F9F64FEE /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Multi-Party-Call/Pods-Multi-Party-Call-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		681E6C6C5B35313110552B6D /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Multi-Party-Call/Pods-Multi-Party-Call-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -596,7 +674,7 @@
 		};
 		A5B6112018F2845100841E6B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B025DECC3717D60FD82CE247 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 76F642B75E225B22C6B09C28 /* Pods-Multi-Party-Call.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -623,7 +701,7 @@
 		};
 		A5B6112118F2845100841E6B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 32C9E834B2AC4F7798E0C4B0 /* Pods.release.xcconfig */;
+			baseConfigurationReference = 1AFF0C35675122ABDB60918F /* Pods-Multi-Party-Call.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -650,6 +728,7 @@
 		};
 		A5B6112318F2845100841E6B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 46E5EF39F9308BD8F61C221E /* Pods-Multi-Party-CallTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Multi-Party-Call.app/Multi-Party-Call";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -672,6 +751,7 @@
 		};
 		A5B6112418F2845100841E6B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DB3F032E054DBDBAB2AEA34D /* Pods-Multi-Party-CallTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Multi-Party-Call.app/Multi-Party-Call";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/6.Audio-Levels/Audio-Levels.xcodeproj/project.pbxproj
+++ b/6.Audio-Levels/Audio-Levels.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0C1685281A71923100A507E3 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C1685271A71923100A507E3 /* libc++.dylib */; };
-		1ADBA0A4D600465FEB249C0A /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D12FC3B5E472603F88F710DE /* libPods.a */; };
+		84D76816218847D96DC84EBF /* libPods-Audio-LevelsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F90E2039FAA6E650BC82C49D /* libPods-Audio-LevelsTests.a */; };
 		A51739F2198A4E3A005102BE /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A51739F1198A4E3A005102BE /* VideoToolbox.framework */; };
 		A57C4CAC199DD64300210EC3 /* OpenTok.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A57C4CAB199DD64300210EC3 /* OpenTok.framework */; };
 		A5F48452198A3C0E00E6C689 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5F48451198A3C0E00E6C689 /* Foundation.framework */; };
@@ -61,6 +61,7 @@
 		A5F484DD198A467300E6C689 /* speakerActive@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A5F484CF198A467300E6C689 /* speakerActive@2x.png */; };
 		A5F484DE198A467300E6C689 /* speakerMuted.png in Resources */ = {isa = PBXBuildFile; fileRef = A5F484D0198A467300E6C689 /* speakerMuted.png */; };
 		A5F484DF198A467300E6C689 /* speakerMuted@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A5F484D1198A467300E6C689 /* speakerMuted@2x.png */; };
+		FB4F430902EDFF57F1DA78DA /* libPods-Audio-Levels.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EBB863350B11EAD98EED1129 /* libPods-Audio-Levels.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,7 +76,10 @@
 
 /* Begin PBXFileReference section */
 		0C1685271A71923100A507E3 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
+		144881B59EDEF514EC87A894 /* Pods-Audio-LevelsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Audio-LevelsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Audio-LevelsTests/Pods-Audio-LevelsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		51735C3617904C46A5031F4A /* Pods-Audio-LevelsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Audio-LevelsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Audio-LevelsTests/Pods-Audio-LevelsTests.release.xcconfig"; sourceTree = "<group>"; };
 		55DFA42F6886A97AD76CB393 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		7B737F70D9A72E47D40BB5A5 /* Pods-Audio-Levels.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Audio-Levels.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Audio-Levels/Pods-Audio-Levels.debug.xcconfig"; sourceTree = "<group>"; };
 		895F27CDB5D7A8394C536344 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		A51739F1198A4E3A005102BE /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		A57C4CAB199DD64300210EC3 /* OpenTok.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OpenTok.framework; sourceTree = "<group>"; };
@@ -137,6 +141,9 @@
 		A5F484D0198A467300E6C689 /* speakerMuted.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = speakerMuted.png; sourceTree = "<group>"; };
 		A5F484D1198A467300E6C689 /* speakerMuted@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "speakerMuted@2x.png"; sourceTree = "<group>"; };
 		D12FC3B5E472603F88F710DE /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		EBB863350B11EAD98EED1129 /* libPods-Audio-Levels.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Audio-Levels.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4AFD2EB6308B3FE38483233 /* Pods-Audio-Levels.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Audio-Levels.release.xcconfig"; path = "Pods/Target Support Files/Pods-Audio-Levels/Pods-Audio-Levels.release.xcconfig"; sourceTree = "<group>"; };
+		F90E2039FAA6E650BC82C49D /* libPods-Audio-LevelsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Audio-LevelsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,7 +168,7 @@
 				A5F48497198A438C00E6C689 /* libsqlite3.dylib in Frameworks */,
 				A5F48456198A3C0E00E6C689 /* UIKit.framework in Frameworks */,
 				A5F48452198A3C0E00E6C689 /* Foundation.framework in Frameworks */,
-				1ADBA0A4D600465FEB249C0A /* libPods.a in Frameworks */,
+				FB4F430902EDFF57F1DA78DA /* libPods-Audio-Levels.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -171,6 +178,7 @@
 			files = (
 				A5F48476198A3C0E00E6C689 /* UIKit.framework in Frameworks */,
 				A5F48475198A3C0E00E6C689 /* Foundation.framework in Frameworks */,
+				84D76816218847D96DC84EBF /* libPods-Audio-LevelsTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -182,6 +190,10 @@
 			children = (
 				895F27CDB5D7A8394C536344 /* Pods.debug.xcconfig */,
 				55DFA42F6886A97AD76CB393 /* Pods.release.xcconfig */,
+				7B737F70D9A72E47D40BB5A5 /* Pods-Audio-Levels.debug.xcconfig */,
+				F4AFD2EB6308B3FE38483233 /* Pods-Audio-Levels.release.xcconfig */,
+				144881B59EDEF514EC87A894 /* Pods-Audio-LevelsTests.debug.xcconfig */,
+				51735C3617904C46A5031F4A /* Pods-Audio-LevelsTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -227,6 +239,8 @@
 				A5F48453198A3C0E00E6C689 /* CoreGraphics.framework */,
 				A5F48455198A3C0E00E6C689 /* UIKit.framework */,
 				D12FC3B5E472603F88F710DE /* libPods.a */,
+				EBB863350B11EAD98EED1129 /* libPods-Audio-Levels.a */,
+				F90E2039FAA6E650BC82C49D /* libPods-Audio-LevelsTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -309,11 +323,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A5F48483198A3C0E00E6C689 /* Build configuration list for PBXNativeTarget "Audio-Levels" */;
 			buildPhases = (
-				B20B7C2E46567A902F6725CF /* Check Pods Manifest.lock */,
+				B20B7C2E46567A902F6725CF /* 📦 Check Pods Manifest.lock */,
 				A5F4844A198A3C0E00E6C689 /* Sources */,
 				A5F4844B198A3C0E00E6C689 /* Frameworks */,
 				A5F4844C198A3C0E00E6C689 /* Resources */,
-				30C19CA7FB268F21AAB48037 /* Copy Pods Resources */,
+				30C19CA7FB268F21AAB48037 /* 📦 Copy Pods Resources */,
+				80D2905F273070F4E92A775C /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -328,9 +343,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A5F48486198A3C0E00E6C689 /* Build configuration list for PBXNativeTarget "Audio-LevelsTests" */;
 			buildPhases = (
+				D4CCC26D9A45AE88A0C93917 /* 📦 Check Pods Manifest.lock */,
 				A5F4846E198A3C0E00E6C689 /* Sources */,
 				A5F4846F198A3C0E00E6C689 /* Frameworks */,
 				A5F48470198A3C0E00E6C689 /* Resources */,
+				B60141C35594FF9E46C49B59 /* 📦 Embed Pods Frameworks */,
+				28A2811F2D1F7334541F2011 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -422,29 +440,89 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		30C19CA7FB268F21AAB48037 /* Copy Pods Resources */ = {
+		28A2811F2D1F7334541F2011 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Audio-LevelsTests/Pods-Audio-LevelsTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B20B7C2E46567A902F6725CF /* Check Pods Manifest.lock */ = {
+		30C19CA7FB268F21AAB48037 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Audio-Levels/Pods-Audio-Levels-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		80D2905F273070F4E92A775C /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Audio-Levels/Pods-Audio-Levels-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B20B7C2E46567A902F6725CF /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		B60141C35594FF9E46C49B59 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Audio-LevelsTests/Pods-Audio-LevelsTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D4CCC26D9A45AE88A0C93917 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -585,7 +663,7 @@
 		};
 		A5F48484198A3C0E00E6C689 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 895F27CDB5D7A8394C536344 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 7B737F70D9A72E47D40BB5A5 /* Pods-Audio-Levels.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -600,7 +678,7 @@
 		};
 		A5F48485198A3C0E00E6C689 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 55DFA42F6886A97AD76CB393 /* Pods.release.xcconfig */;
+			baseConfigurationReference = F4AFD2EB6308B3FE38483233 /* Pods-Audio-Levels.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -615,6 +693,7 @@
 		};
 		A5F48487198A3C0E00E6C689 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 144881B59EDEF514EC87A894 /* Pods-Audio-LevelsTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Audio-Levels.app/Audio-Levels";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -637,6 +716,7 @@
 		};
 		A5F48488198A3C0E00E6C689 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 51735C3617904C46A5031F4A /* Pods-Audio-LevelsTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Audio-Levels.app/Audio-Levels";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/7.External-Audio-Device/External-Audio-Device.xcodeproj/project.pbxproj
+++ b/7.External-Audio-Device/External-Audio-Device.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 		A5D01FB81A3A1397005D84F9 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D01FB71A3A1397005D84F9 /* VideoToolbox.framework */; };
 		A5E74EB01C90D054002CBE09 /* OTDefaultAudioDeviceWithVolumeControl.m in Sources */ = {isa = PBXBuildFile; fileRef = A5E74EAE1C90D054002CBE09 /* OTDefaultAudioDeviceWithVolumeControl.m */; };
 		AA926F4FAAC2A2F9DABFC35D /* libPods-External-Audio-DeviceTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E5491F5A48594DE9AF5D392B /* libPods-External-Audio-DeviceTests.a */; };
-		D4D55F6E1D5E1D6E008DC3AD /* libPods-External-Audio-Device.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D55F6D1D5E1D6E008DC3AD /* libPods-External-Audio-Device.a */; };
+		D4D55F7E1D762270008DC3AD /* libPods-External-Audio-Device.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 943E500C5D5F5093F7988BBA /* libPods-External-Audio-Device.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,7 +104,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4D55F6E1D5E1D6E008DC3AD /* libPods-External-Audio-Device.a in Frameworks */,
 				0C1685201A71913F00A507E3 /* libc++.dylib in Frameworks */,
 				A5D01FB81A3A1397005D84F9 /* VideoToolbox.framework in Frameworks */,
 				0CBBA443196B55EA005F55D4 /* libsqlite3.dylib in Frameworks */,
@@ -121,6 +120,7 @@
 				0CBBA3F2196B5192005F55D4 /* CoreGraphics.framework in Frameworks */,
 				0CBBA3F4196B5192005F55D4 /* UIKit.framework in Frameworks */,
 				0CBBA3F0196B5192005F55D4 /* Foundation.framework in Frameworks */,
+				D4D55F7E1D762270008DC3AD /* libPods-External-Audio-Device.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/8.Screen-Sharing/Screen-Sharing.xcodeproj/project.pbxproj
+++ b/8.Screen-Sharing/Screen-Sharing.xcodeproj/project.pbxproj
@@ -36,7 +36,6 @@
 		0C99B7BE19AE913A00A60ABA /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C99B7B019AE913A00A60ABA /* QuartzCore.framework */; };
 		0CC1C07F19B7C23F00BD819F /* TBScreenCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CC1C07A19B7C23F00BD819F /* TBScreenCapture.m */; };
 		0CC1C08319B7C6D600BD819F /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CC1C08219B7C6D600BD819F /* Accelerate.framework */; };
-		28DDDB628DA40355DC810653 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FABAC0704DF5C8CD82166D79 /* libPods.a */; };
 		937E3C4857A0A002D3C63517 /* libPods-Screen-SharingTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FB895B40DD1C0074BC08F03 /* libPods-Screen-SharingTests.a */; };
 		A3EAD4329912AA1045B0715F /* libPods-Screen-Sharing.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ED43E618AE9053AFCE334576 /* libPods-Screen-Sharing.a */; };
 		D4AF64361A23B5E20026C892 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4AF64351A23B5E20026C892 /* VideoToolbox.framework */; };
@@ -122,7 +121,6 @@
 				0C99B76A19AE909300A60ABA /* Foundation.framework in Frameworks */,
 				0C99B7B419AE913A00A60ABA /* libsqlite3.dylib in Frameworks */,
 				0C99B7B619AE913A00A60ABA /* GLKit.framework in Frameworks */,
-				28DDDB628DA40355DC810653 /* libPods.a in Frameworks */,
 				A3EAD4329912AA1045B0715F /* libPods-Screen-Sharing.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/9.Ringtones/Ringtones.xcodeproj/project.pbxproj
+++ b/9.Ringtones/Ringtones.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5B0567A2B18619E963A94EA2 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 12985DF2387F03EF524AF949 /* libPods.a */; };
+		063004E7EBDD92FB8687F1E9 /* libPods-RingtonesTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B9042836B7BA6F4B9E618231 /* libPods-RingtonesTests.a */; };
+		C3A3916F1743AD747B73E0D6 /* libPods-Ringtones.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 073BF333C5D28BB771FDC8ED /* libPods-Ringtones.a */; };
 		D415AB251C74052800A070E1 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D415AB241C74052800A070E1 /* main.m */; };
 		D415AB281C74052800A070E1 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D415AB271C74052800A070E1 /* AppDelegate.m */; };
 		D415AB2B1C74052800A070E1 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D415AB2A1C74052800A070E1 /* ViewController.m */; };
@@ -39,9 +40,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		073BF333C5D28BB771FDC8ED /* libPods-Ringtones.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Ringtones.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		12985DF2387F03EF524AF949 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		532AB47470C1524CAA2138D0 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		6F03B856CDFC9D47091E3779 /* Pods-RingtonesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RingtonesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RingtonesTests/Pods-RingtonesTests.release.xcconfig"; sourceTree = "<group>"; };
 		834B325DAB6AD554F90CFABA /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		95B490DA4F7B9AFEC550BBF4 /* Pods-Ringtones.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Ringtones.release.xcconfig"; path = "Pods/Target Support Files/Pods-Ringtones/Pods-Ringtones.release.xcconfig"; sourceTree = "<group>"; };
+		B9042836B7BA6F4B9E618231 /* libPods-RingtonesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RingtonesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE8B5B5429B44EF131299801 /* Pods-Ringtones.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Ringtones.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Ringtones/Pods-Ringtones.debug.xcconfig"; sourceTree = "<group>"; };
 		D415AB201C74052800A070E1 /* Ringtones.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ringtones.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D415AB241C74052800A070E1 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		D415AB261C74052800A070E1 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -63,6 +69,7 @@
 		D415AB5A1C74083D00A070E1 /* OTAudioDeviceRingtone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OTAudioDeviceRingtone.h; sourceTree = "<group>"; };
 		D415AB5B1C74083D00A070E1 /* OTAudioDeviceRingtone.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTAudioDeviceRingtone.m; sourceTree = "<group>"; };
 		D415AB5D1C7409AD00A070E1 /* bananaphone.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = bananaphone.mp3; sourceTree = "<group>"; };
+		F5BC4DE2473C8D3A356CAF72 /* Pods-RingtonesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RingtonesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RingtonesTests/Pods-RingtonesTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,7 +77,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B0567A2B18619E963A94EA2 /* libPods.a in Frameworks */,
+				C3A3916F1743AD747B73E0D6 /* libPods-Ringtones.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +85,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				063004E7EBDD92FB8687F1E9 /* libPods-RingtonesTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -173,6 +181,10 @@
 			children = (
 				532AB47470C1524CAA2138D0 /* Pods.debug.xcconfig */,
 				834B325DAB6AD554F90CFABA /* Pods.release.xcconfig */,
+				BE8B5B5429B44EF131299801 /* Pods-Ringtones.debug.xcconfig */,
+				95B490DA4F7B9AFEC550BBF4 /* Pods-Ringtones.release.xcconfig */,
+				F5BC4DE2473C8D3A356CAF72 /* Pods-RingtonesTests.debug.xcconfig */,
+				6F03B856CDFC9D47091E3779 /* Pods-RingtonesTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -181,6 +193,8 @@
 			isa = PBXGroup;
 			children = (
 				12985DF2387F03EF524AF949 /* libPods.a */,
+				073BF333C5D28BB771FDC8ED /* libPods-Ringtones.a */,
+				B9042836B7BA6F4B9E618231 /* libPods-RingtonesTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -192,11 +206,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D415AB4D1C74052800A070E1 /* Build configuration list for PBXNativeTarget "Ringtones" */;
 			buildPhases = (
-				E59049AAF532D79D81941E30 /* Check Pods Manifest.lock */,
+				E59049AAF532D79D81941E30 /* 📦 Check Pods Manifest.lock */,
 				D415AB1C1C74052800A070E1 /* Sources */,
 				D415AB1D1C74052800A070E1 /* Frameworks */,
 				D415AB1E1C74052800A070E1 /* Resources */,
-				AC4EE45521324EE90FFB31FF /* Copy Pods Resources */,
+				AC4EE45521324EE90FFB31FF /* 📦 Copy Pods Resources */,
+				F6ACFD0B717288B521726E24 /* 📦 Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -211,9 +226,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D415AB501C74052800A070E1 /* Build configuration list for PBXNativeTarget "RingtonesTests" */;
 			buildPhases = (
+				ADF54062736DC722F97C407A /* 📦 Check Pods Manifest.lock */,
 				D415AB351C74052800A070E1 /* Sources */,
 				D415AB361C74052800A070E1 /* Frameworks */,
 				D415AB371C74052800A070E1 /* Resources */,
+				AE5F1D7F827EA04462649F74 /* 📦 Embed Pods Frameworks */,
+				4B74998DA0DE4EC274845B9D /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -319,34 +337,94 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		AC4EE45521324EE90FFB31FF /* Copy Pods Resources */ = {
+		4B74998DA0DE4EC274845B9D /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RingtonesTests/Pods-RingtonesTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E59049AAF532D79D81941E30 /* Check Pods Manifest.lock */ = {
+		AC4EE45521324EE90FFB31FF /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Ringtones/Pods-Ringtones-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ADF54062736DC722F97C407A /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		AE5F1D7F827EA04462649F74 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RingtonesTests/Pods-RingtonesTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E59049AAF532D79D81941E30 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		F6ACFD0B717288B521726E24 /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Ringtones/Pods-Ringtones-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -499,7 +577,7 @@
 		};
 		D415AB4E1C74052800A070E1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 532AB47470C1524CAA2138D0 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = BE8B5B5429B44EF131299801 /* Pods-Ringtones.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
@@ -512,7 +590,7 @@
 		};
 		D415AB4F1C74052800A070E1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 834B325DAB6AD554F90CFABA /* Pods.release.xcconfig */;
+			baseConfigurationReference = 95B490DA4F7B9AFEC550BBF4 /* Pods-Ringtones.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ENABLE_BITCODE = NO;
@@ -525,6 +603,7 @@
 		};
 		D415AB511C74052800A070E1 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F5BC4DE2473C8D3A356CAF72 /* Pods-RingtonesTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = RingtonesTests/Info.plist;
@@ -537,6 +616,7 @@
 		};
 		D415AB521C74052800A070E1 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6F03B856CDFC9D47091E3779 /* Pods-RingtonesTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = RingtonesTests/Info.plist;


### PR DESCRIPTION
Newer versions of cocoapods make named libpods static libs. Without the older
libpods static library builds, all these builds break.