### PR TITLE
OPENTOK-40693:Enable background modes of projects for the property Audio,AirPlay,PIP. r=robjperez

### DIFF
--- a/Archiving/Archiving.xcodeproj/project.pbxproj
+++ b/Archiving/Archiving.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Archiving/Archiving.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Archiving/Archiving.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Archiving/Archiving/Info.plist
+++ b/Archiving/Archiving/Info.plist
@@ -33,6 +33,10 @@
 	<string>This app accesses the camera for video communications.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app accesses the microphone for audio communications.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Audio-Levels/Audio-Levels.xcodeproj/project.pbxproj
+++ b/Audio-Levels/Audio-Levels.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Audio-Levels/Audio-Levels.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Audio-Levels/Audio-Levels.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Audio-Levels/Audio-Levels/Audio-Levels-Info.plist
+++ b/Audio-Levels/Audio-Levels/Audio-Levels-Info.plist
@@ -28,6 +28,10 @@
 	<string>Opentok needs access to the camera to stream your video</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Basic-Video-Chat/Basic-Video-Chat/Info.plist
+++ b/Basic-Video-Chat/Basic-Video-Chat/Info.plist
@@ -28,6 +28,10 @@
 	<string>Opentok needs access to the camera to stream your video</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>

--- a/Broadcast-Ext/Broadcast-Ext/Info.plist
+++ b/Broadcast-Ext/Broadcast-Ext/Info.plist
@@ -28,6 +28,10 @@
 	<string>Opentok needs access to the camera to stream your video</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>

--- a/Custom-Audio-Driver/Custom-Audio-Driver.xcodeproj/project.pbxproj
+++ b/Custom-Audio-Driver/Custom-Audio-Driver.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Custom-Audio-Driver/Custom-Audio-Driver.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Custom-Audio-Driver/Custom-Audio-Driver.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Custom-Audio-Driver/External-Audio-Device/Custom-Audio-Driver-Info.plist
+++ b/Custom-Audio-Driver/External-Audio-Device/Custom-Audio-Driver-Info.plist
@@ -30,6 +30,7 @@
 	<string>Opentok needs access to the microphone to stream your audio</string>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>voip</string>
 	</array>
 	<key>UILaunchStoryboardName</key>

--- a/Custom-Video-Driver/Custom-Video-Driver.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Custom-Video-Driver/Custom-Video-Driver.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/Custom-Video-Driver-Info.plist
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/Custom-Video-Driver-Info.plist
@@ -28,6 +28,10 @@
 	<string>Opentok needs access to the camera to stream your video</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>

--- a/FrameMetadata/FrameMetadata.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/FrameMetadata/FrameMetadata.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/FrameMetadata/FrameMetadata/FrameMetadata.plist
+++ b/FrameMetadata/FrameMetadata/FrameMetadata.plist
@@ -30,6 +30,10 @@
 	<string>Location is required to find out where you are.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile</key>

--- a/Live-Photo-Capture/Live-Photo-Capture.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Live-Photo-Capture/Live-Photo-Capture.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Live-Photo-Capture/Live-Photo-Capture/Live-Photo-Capture-Info.plist
+++ b/Live-Photo-Capture/Live-Photo-Capture/Live-Photo-Capture-Info.plist
@@ -28,6 +28,10 @@
 	<string>Opentok needs access to the camera to stream your video</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile</key>

--- a/Overlay-Graphics/Overlay-Graphics.xcodeproj/project.pbxproj
+++ b/Overlay-Graphics/Overlay-Graphics.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Overlay-Graphics/Overlay-Graphics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Overlay-Graphics/Overlay-Graphics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Overlay-Graphics/Overlay-Graphics/Overlay-Graphics-Info.plist
+++ b/Overlay-Graphics/Overlay-Graphics/Overlay-Graphics-Info.plist
@@ -28,6 +28,10 @@
 	<string>Opentok needs access to the camera to stream your video</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile</key>

--- a/Ringtones/Ringtones.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Ringtones/Ringtones.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Screen-Sharing/Screen-Sharing.xcodeproj/project.pbxproj
+++ b/Screen-Sharing/Screen-Sharing.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Screen-Sharing/Screen-Sharing.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Screen-Sharing/Screen-Sharing.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Screen-Sharing/Screen-Sharing/Screen-Sharing-Info.plist
+++ b/Screen-Sharing/Screen-Sharing/Screen-Sharing-Info.plist
@@ -28,6 +28,10 @@
 	<string>Opentok needs access to the camera to stream your video</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Opentok needs access to the microphone to stream your audio</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>

--- a/Signaling/Signaling.xcodeproj/project.pbxproj
+++ b/Signaling/Signaling.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/Signaling/Signaling.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Signaling/Signaling.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Signaling/Signaling/Info.plist
+++ b/Signaling/Signaling/Info.plist
@@ -28,6 +28,10 @@
 	<string>This app accesses the camera for video communications.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app accesses the microphone for audio communications.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Simple-Multiparty/Simple-Multiparty.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Simple-Multiparty/Simple-Multiparty.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
An offshoot of the issue - https://github.com/opentok/opentok-ios-sdk-samples-swift/issues/75

Many users miss this step and they panic and have to ping Customer Support, learn about it, make the change and waste valuable time.
Did the same for Swift projects too https://github.com/opentok/opentok-ios-sdk-samples-swift/pull/112
Xcode version: 11.3.1

For the new file `IDEWorkspaceChecks.plist` refer https://stackoverflow.com/questions/49564513/new-file-created-in-xcode-9-3-wsname-xcworkspace-xcshareddata-ideworkspaceche