### PR TITLE
Opentok 40943: Fix rear cam publisher disappearing when subscriber is added.

### DIFF
--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
@@ -40,7 +40,7 @@
     TBExampleVideoRender* _rearCamPublisherVideoRenderView;
     
 }
-static double widgetHeight = 190;
+static double widgetHeight = 180;
 static double widgetWidth = 320;
 
 // *** Fill the following variables using your own Project info  ***

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
@@ -40,7 +40,7 @@
     TBExampleVideoRender* _rearCamPublisherVideoRenderView;
     
 }
-static double widgetHeight = 240;
+static double widgetHeight = 190;
 static double widgetWidth = 320;
 
 // *** Fill the following variables using your own Project info  ***
@@ -296,8 +296,7 @@ didFailWithError:(OTError*)error
 {
     NSLog(@"subscriberDidConnectToStream (%@)",
           subscriber.stream.connection.connectionId);
-    [_subscriberVideoRenderView setFrame:CGRectMake(0, widgetHeight, widgetWidth,
-                                         widgetHeight)];
+    [_subscriberVideoRenderView setFrame:CGRectMake(0, (_rearCamPublisher ? widgetHeight * 2: widgetHeight), widgetWidth, widgetHeight)];
     [self.view addSubview:_subscriberVideoRenderView];
 }
 


### PR DESCRIPTION
Purpose of the ticket:
Fix rear cam publisher disappearing when subscriber is added.

How to test manually?
Run the app with both front and rare camera and add subscriber. Both publishers and subscriber should appear.

Ticket:
https://tokbox.atlassian.net/browse/OPENTOK-40943