### PR TITLE
OPENTOK-44873: iOS screen broadcasting - background behavior

### DIFF
--- a/Broadcast-Ext/OpenTok Live/OTBroadcastExtHelper.m
+++ b/Broadcast-Ext/OpenTok Live/OTBroadcastExtHelper.m
@@ -20,7 +20,7 @@
     
     // OT vars
     OTSession* _session;
-    OTPublisher* _publisher;
+    OTPublisherKit* _publisher;
     OTSubscriber* _subscriber;
     OTBroadcastExtAudioDevice* _audioDevice;
     
@@ -100,8 +100,8 @@
     
     settings.name = [[UIDevice currentDevice] name];
     _publisher =
-    [[OTPublisher alloc] initWithDelegate:self
-                                 settings:settings];
+    [[OTPublisherKit alloc] initWithDelegate:self
+                                    settings:settings];
     
     // We need to set publishAudio to false
     // since we don't know the broadcast session is


### PR DESCRIPTION
For screen sharing there is reason to `OTPublisher` class, so it was replaced with `OTPublisherKit` to avoid un-publish action on background mode.