### PR TITLE
VIDCS-710: Samples do not build on M1 mac (after update to OpenTok 2.24.2)

### DIFF
--- a/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
+++ b/Basic-Video-Chat/Basic-Video-Chat.xcodeproj/project.pbxproj
@@ -276,7 +276,6 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PR6C39UQ38;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"${SRCROOT}",
@@ -356,7 +355,6 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PR6C39UQ38;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"${SRCROOT}",


### PR DESCRIPTION
#### What is this PR doing?
Removes the override of "EXCLUDED_ARCHS[sdk=iphonesimulator*]"

#### How should this be manually tested?
Execute `pod install` and run `Basic-Video-Chat` project.

#### What are the relevant tickets?
[VIDCS-710](https://jira.vonage.com/browse/VIDCS-710)
