### PR TITLE
VIDCS-1860, VIDCS-1876, VIDCS-1948, VIDCS-1943: AVCapture is only referenced from one queue

### DIFF
--- a/Custom-Video-Driver/Lets-Build-OTPublisher/Single-Cam-Capturer/TBExampleVideoCapture.h
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/Single-Cam-Capturer/TBExampleVideoCapture.h
@@ -16,11 +16,7 @@
 @end
 
 @interface TBExampleVideoCapture : NSObject
-    <AVCaptureVideoDataOutputSampleBufferDelegate, OTVideoCapture>
-{
-    @protected
-    dispatch_queue_t _capture_queue;
-}
+    <AVCaptureVideoDataOutputSampleBufferDelegate, OTVideoCapture> { }
 
 @property (nonatomic, retain) AVCaptureSession *captureSession;
 @property (nonatomic, retain) AVCaptureVideoDataOutput *videoOutput;

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/Single-Cam-Capturer/TBExampleVideoCapture.m
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/Single-Cam-Capturer/TBExampleVideoCapture.m
@@ -54,7 +54,6 @@ static dispatch_queue_t _captureQueue;
 
 + (void)initialize {
     if (self == [TBExampleVideoCaptureShared class]) {
-    //    _captureQueue = dispatch_get_main_queue();
         _captureQueue = dispatch_queue_create("com.tokbox.OTVideoCapture", DISPATCH_QUEUE_SERIAL);
     }
 }

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
@@ -17,7 +17,6 @@
 // iOS supports multi cam only on higher end devices (e.g, >= A12 CPU)
 // The capturer will return nil if you try to run multi cam samples on an unsupported device!
 #define USE_MULTICAM_SESSION 0
-#define TAP_TO_UNPUBLISHPUBLISH_ 1
 
 @interface OTSession ()
     
@@ -71,28 +70,6 @@ static NSString* const kToken = @"";
                                            delegate:self];
 
     [self doConnect];
-    if(TAP_TO_UNPUBLISHPUBLISH_) {
-        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
-        [self.view addGestureRecognizer:tapGesture];
-    }
-}
-
-- (void)handleTap:(UITapGestureRecognizer *)sender {
-    if(TAP_TO_UNPUBLISHPUBLISH_) {
-        [_session unpublish:_frontCamPublisher error:nil];
-        // We need to wait for unpublisher delegate to be triggered
-        // - (void):(OTPublisherKit*)publisher:(OTStream *)stream
-    }
-}
-
-- (void)publishAfterTap{
-    if(TAP_TO_UNPUBLISHPUBLISH_) {
-        _frontCamPublisher = nil;
-        NSLog(@"Do publisher");
-        [self doPublishWithFrontCam];
-        if(USE_MULTICAM_SESSION == 1)
-            [self doPublishWithRearCam];
-    }
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -355,9 +332,6 @@ didFailWithError:(OTError*)error
     [self cleanupPublisher];
     
     NSLog(@"publisher destroyed");
-    if(TAP_TO_UNPUBLISHPUBLISH_) {
-        [self publishAfterTap];
-    }
 }
 
 - (void)publisher:(OTPublisherKit*)publisher

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
@@ -57,11 +57,6 @@ static NSString* const kToken = @"";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-
-    if ([kApiKey isEqualToString:@""] || [kSessionId isEqualToString:@""] || [kToken isEqualToString:@""]) {
-        NSLog(@"Session credentials not set");
-        return;
-    }
     
     // Step 1: As the view comes into the foreground, initialize a new instance
     // of OTSession and begin the connection process.
@@ -330,8 +325,6 @@ didFailWithError:(OTError*)error
     }
     
     [self cleanupPublisher];
-    
-    NSLog(@"publisher destroyed");
 }
 
 - (void)publisher:(OTPublisherKit*)publisher

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/ViewController.m
@@ -17,6 +17,7 @@
 // iOS supports multi cam only on higher end devices (e.g, >= A12 CPU)
 // The capturer will return nil if you try to run multi cam samples on an unsupported device!
 #define USE_MULTICAM_SESSION 0
+#define TAP_TO_UNPUBLISHPUBLISH_ 1
 
 @interface OTSession ()
     
@@ -57,6 +58,11 @@ static NSString* const kToken = @"";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+
+    if ([kApiKey isEqualToString:@""] || [kSessionId isEqualToString:@""] || [kToken isEqualToString:@""]) {
+        NSLog(@"Session credentials not set");
+        return;
+    }
     
     // Step 1: As the view comes into the foreground, initialize a new instance
     // of OTSession and begin the connection process.
@@ -65,6 +71,28 @@ static NSString* const kToken = @"";
                                            delegate:self];
 
     [self doConnect];
+    if(TAP_TO_UNPUBLISHPUBLISH_) {
+        UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
+        [self.view addGestureRecognizer:tapGesture];
+    }
+}
+
+- (void)handleTap:(UITapGestureRecognizer *)sender {
+    if(TAP_TO_UNPUBLISHPUBLISH_) {
+        [_session unpublish:_frontCamPublisher error:nil];
+        // We need to wait for unpublisher delegate to be triggered
+        // - (void):(OTPublisherKit*)publisher:(OTStream *)stream
+    }
+}
+
+- (void)publishAfterTap{
+    if(TAP_TO_UNPUBLISHPUBLISH_) {
+        _frontCamPublisher = nil;
+        NSLog(@"Do publisher");
+        [self doPublishWithFrontCam];
+        if(USE_MULTICAM_SESSION == 1)
+            [self doPublishWithRearCam];
+    }
 }
 
 - (BOOL)prefersStatusBarHidden
@@ -325,6 +353,11 @@ didFailWithError:(OTError*)error
     }
     
     [self cleanupPublisher];
+    
+    NSLog(@"publisher destroyed");
+    if(TAP_TO_UNPUBLISHPUBLISH_) {
+        [self publishAfterTap];
+    }
 }
 
 - (void)publisher:(OTPublisherKit*)publisher


### PR DESCRIPTION
**What is this PR doing?**
AVCapture is no longer being referenced from multiple queues. There is a static queue for the capture now.
Safely dispatch async in dealloc avoiding segmentation fault.
Move several sync calls to async.

Issue easily reproducible on 2.27.1 with following TestApp changes. In this PR issue should not be reproducible.

```
// Change to NO to subscribe to streams other than your own.
@@ -56,8 +53,15 @@ - (void)viewDidLoad
                                       sessionId:kSessionId
                                        delegate:self];
    [self doConnect];
    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
    [self.view addGestureRecognizer:tapGesture];
}
- (void)handleTap:(UITapGestureRecognizer *)sender {
    [_session unpublish:_publisher error:nil];
    _publisher = nil;
    [self doPublish];

}

- (BOOL)prefersStatusBarHidden
{
    return YES;
@@ -83,7 +87,7 @@ - (BOOL)shouldAutorotateToInterfaceOrientation:
 */

```

In order to test the changes of setting AVcapture session from sync to async, we need test as well:

changing frame rate;
changing camera resolution;
changing camera (back to front and vice-versa)

What are the relevant tickets?
[VIDCS-1860](https://jira.vonage.com/browse/VIDCS-1860)
[VIDCS-1876](https://jira.vonage.com/browse/VIDCS-1876)
[VIDCS-1948](https://jira.vonage.com/browse/VIDCS-1948)
[VIDCS-1943](https://jira.vonage.com/browse/VIDCS-1943)