### PR TITLE
AGC and (AEC,NS) support at Audio Unit level

### DIFF
--- a/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDevice.h
+++ b/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDevice.h
@@ -30,6 +30,16 @@
  */
 @property (nonatomic, readonly) BOOL bluetoothDeviceAvailable;
 
+/**
+ AEC and NS are disabled together. No separate disabling is allowed by Apple AU API's. .Default is FALSE.
+ */
+@property (nonatomic) BOOL disableAudioProcessing;
+
+/**
+ Enable Automatic Gain Control. Default is TRUE.
+ */
+@property (nonatomic) BOOL enableAGC;
+
 - (BOOL)setAudioBus:(id<OTAudioBus>)audioBus;
 
 - (OTAudioFormat*)captureFormat;

--- a/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDevice.m
+++ b/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDevice.m
@@ -121,6 +121,8 @@ static OSStatus playout_cb(void *ref_con,
         _safetyQueue = dispatch_queue_create("ot-audio-driver",
                                              DISPATCH_QUEUE_SERIAL);
         _restartRetryCount = 0;
+        self.disableAudioProcessing = FALSE;
+        self.enableAGC = TRUE;
     }
     return self;
 }
@@ -1086,6 +1088,22 @@ static OSStatus playout_cb(void *ref_con,
         AudioUnitSetProperty(*voice_unit, kAudioOutputUnitProperty_EnableIO,
                              kAudioUnitScope_Output, kOutputBus, &enable_output,
                              sizeof(enable_output));
+        UInt32 bypassVoiceProcessing = self.disableAudioProcessing;
+        CheckError(AudioUnitSetProperty(*voice_unit,
+                                       kAUVoiceIOProperty_BypassVoiceProcessing,
+                                       kAudioUnitScope_Global,
+                                       kInputBus,
+                                       &bypassVoiceProcessing,
+                                        sizeof(bypassVoiceProcessing)),
+                   @"kAUVoiceIOProperty_BypassVoiceProcessing failed");
+        UInt32 enableAGC = self.enableAGC;
+        CheckError(AudioUnitSetProperty(*voice_unit,
+                                       kAUVoiceIOProperty_VoiceProcessingEnableAGC,
+                                       kAudioUnitScope_Global,
+                                       kInputBus,
+                                       &enableAGC,
+                                       sizeof(enableAGC)),
+                   @"kAUVoiceIOProperty_VoiceProcessingEnableAGC failed");
         
     } else
     {
@@ -1102,6 +1120,22 @@ static OSStatus playout_cb(void *ref_con,
                              kAudioUnitScope_Input, kInputBus, &enable_input,
                              sizeof(enable_input));
         [self setPlayOutRenderCallback:*voice_unit];
+        UInt32 bypassVoiceProcessing = self.disableAudioProcessing;
+        CheckError(AudioUnitSetProperty(*voice_unit,
+                                       kAUVoiceIOProperty_BypassVoiceProcessing,
+                                       kAudioUnitScope_Global,
+                                       kInputBus,
+                                       &bypassVoiceProcessing,
+                                        sizeof(bypassVoiceProcessing)),
+                   @"kAUVoiceIOProperty_BypassVoiceProcessing failed");
+        UInt32 enableAGC = self.enableAGC;
+        CheckError(AudioUnitSetProperty(*voice_unit,
+                                       kAUVoiceIOProperty_VoiceProcessingEnableAGC,
+                                       kAudioUnitScope_Global,
+                                       kInputBus,
+                                       &enableAGC,
+                                       sizeof(enableAGC)),
+                   @"kAUVoiceIOProperty_VoiceProcessingEnableAGC failed");
     }
     
     Float64 f64 = 0;

--- a/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDeviceWithVolumeControl.h
+++ b/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDeviceWithVolumeControl.h
@@ -12,4 +12,10 @@
 
 // value range - 0 (min) and 1 (max)
 -(void)setPlayoutVolume:(float)value;
+
+/**
+ * Initializes an audio device with options to enable AGC and bypassing other default audio processing.
+ */
+- (instancetype)initWithAGC:(BOOL)agc disableAudioProcessing:(BOOL) disbaleAudioProcessing;
+
 @end

--- a/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDeviceWithVolumeControl.m
+++ b/Custom-Audio-Driver/External-Audio-Device/OTDefaultAudioDeviceWithVolumeControl.m
@@ -23,6 +23,15 @@
     AudioUnit mixerUnit;
 }
 
+- (instancetype)initWithAGC:(BOOL)agc disableAudioProcessing:(BOOL) disbaleAudioProcessing {
+    self = [super init];
+    if (self) {
+        self.enableAGC = agc;
+        self.disableAudioProcessing = disbaleAudioProcessing;
+    }
+    return self;
+    
+}
 - (BOOL)setupAudioUnit:(AudioUnit *)voice_unit playout:(BOOL)isPlayout
 {
     BOOL result = [super setupAudioUnit:voice_unit playout:isPlayout];

--- a/Custom-Audio-Driver/External-Audio-Device/ViewController.m
+++ b/Custom-Audio-Driver/External-Audio-Device/ViewController.m
@@ -34,8 +34,10 @@ static NSString* const kToken = @"";
 {
     [super viewDidLoad];
     
+//    OTDefaultAudioDeviceWithVolumeControl* audioDevice =
+//    [OTDefaultAudioDeviceWithVolumeControl new];
     OTDefaultAudioDeviceWithVolumeControl* audioDevice =
-    [OTDefaultAudioDeviceWithVolumeControl new];
+    [[OTDefaultAudioDeviceWithVolumeControl alloc] initWithAGC:YES disableAudioProcessing:NO];
     [OTAudioDeviceManager setAudioDevice:audioDevice];
     
     // Step 1: As the view comes into the foreground, initialize a new instance


### PR DESCRIPTION
```objc
       UInt32 bypassVoiceProcessing = self.disableAudioProcessing;
        CheckError(AudioUnitSetProperty(*voice_unit,
                                       kAUVoiceIOProperty_BypassVoiceProcessing,
                                       kAudioUnitScope_Global,
                                       kInputBus,
                                       &bypassVoiceProcessing,
                                        sizeof(bypassVoiceProcessing)),
                   @"kAUVoiceIOProperty_BypassVoiceProcessing failed");
        UInt32 enableAGC = self.enableAGC;
        CheckError(AudioUnitSetProperty(*voice_unit,
                                       kAUVoiceIOProperty_VoiceProcessingEnableAGC,
                                       kAudioUnitScope_Global,
                                       kInputBus,
                                       &enableAGC,
                                       sizeof(enableAGC)),
                   @"kAUVoiceIOProperty_VoiceProcessingEnableAGC failed");
```
and instantiated with 
```objc
    OTDefaultAudioDeviceWithVolumeControl* audioDevice =
    [[OTDefaultAudioDeviceWithVolumeControl alloc] initWithAGC:YES disableAudioProcessing:NO];
```