### PR TITLE
VIDCS-2642: TorchMode method exposed/added in MultiCam capturer

### DIFF
--- a/Custom-Video-Driver/Lets-Build-OTPublisher/Multi-Cam-Capturer/TBExampleMultiCamCapture.h
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/Multi-Cam-Capturer/TBExampleMultiCamCapture.h
@@ -24,6 +24,7 @@
 -(id)initWithCameraPosition:(AVCaptureDevicePosition)camPosition
        andAVMultiCamSession:(AVCaptureMultiCamSession *)multiCamSession
                    useQueue:(dispatch_queue_t)capture_queue;
+- (void) setTorchMode:(AVCaptureTorchMode) torchMode;
 
 @property (nonatomic, weak) AVCaptureSession *captureSession;
 @property (nonatomic, retain) AVCaptureVideoDataOutput *videoOutput;

--- a/Custom-Video-Driver/Lets-Build-OTPublisher/Multi-Cam-Capturer/TBExampleMultiCamCapture.m
+++ b/Custom-Video-Driver/Lets-Build-OTPublisher/Multi-Cam-Capturer/TBExampleMultiCamCapture.m
@@ -432,6 +432,23 @@ typedef NS_ENUM(int32_t, OTCapturerErrorCode) {
     }
 }
 
+- (void) setTorchMode:(AVCaptureTorchMode) torchMode {
+    
+    AVCaptureDevice *device = [[self videoInput] device];
+    if ([device isTorchModeSupported:torchMode] &&
+        [device torchMode] != torchMode)
+    {
+        NSError *error;
+        if ([device lockForConfiguration:&error]) {
+            [device setTorchMode:torchMode];
+            [device unlockForConfiguration];
+        } else {
+            //Handle Error
+        }
+    }
+}
+
+
 - (void)statusBarOrientationChange:(NSNotification *)notification {
     self.currentStatusBarOrientation = [notification.userInfo[UIApplicationStatusBarOrientationUserInfoKey] integerValue];
 }


### PR DESCRIPTION
Adding the method w/o Custom Video drivers leads to freezing and/or wrong implementation. 

A sample code to test would be 
```objc
- (void)handleTap:(UITapGestureRecognizer *)recognizer {
    NSLog(@"View controller was tapped!");
    TBExampleMultiCamCapture* c = (TBExampleMultiCamCapture *) _rearCamPublisher.videoCapture;
    [c setTorchMode:AVCaptureTorchModeOn];
} 
```