### PR TITLE
Ringtone app made simple.

### DIFF
--- a/Ringtones/README.md
+++ b/Ringtones/README.md
@@ -43,7 +43,3 @@ Application Notes
 * There is no timeout for the audio player. If the asset plays to completion or
   there is an error, all calls from OTAudioBus will be passed to the audio
   driver, and playback/capture for OpenTok will proceed as normal.
-
-* An additional tap gesture recognizer has been added to this sample to show
-  and test that this sequence will work through multiple calls. The 
-  `resetSession` method is added to implement this workflow.

--- a/Ringtones/Ringtones/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Ringtones/Ringtones/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,92 +2,97 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "60x60"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "83.5x83.5",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Ringtones/Ringtones/OTAudioDeviceRingtone.h
+++ b/Ringtones/Ringtones/OTAudioDeviceRingtone.h
@@ -18,5 +18,7 @@
 
 // Immediately stops the ringtone and allows OpenTok audio calls to flow
 - (void)stopRingtone;
+- (void)startRingtone;
+- (BOOL)isRingTonePlaying;
 
 @end


### PR DESCRIPTION
We first publish, then stop capturing publisher audio , so we can play a ringtone exclusively on an Apple AVAudioPlayer. When the subscriber joins later (10 seconds)  the ringtone player stops playing. No reset sessions complexity and crashes.